### PR TITLE
Extend NetworkManager inventory

### DIFF
--- a/app/models/manageiq/providers/azure_stack/inventory/collector/network_manager.rb
+++ b/app/models/manageiq/providers/azure_stack/inventory/collector/network_manager.rb
@@ -1,4 +1,12 @@
 class ManageIQ::Providers::AzureStack::Inventory::Collector::NetworkManager < ManageIQ::Providers::AzureStack::Inventory::Collector
+  def networks
+    azure_network.virtual_networks.list_all
+  end
+
+  def network_ports
+    azure_network.network_interfaces.list_all
+  end
+
   def security_groups
     azure_network.network_security_groups.list_all
   end

--- a/app/models/manageiq/providers/azure_stack/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/azure_stack/inventory/parser/network_manager.rb
@@ -3,9 +3,57 @@ class ManageIQ::Providers::AzureStack::Inventory::Parser::NetworkManager < Manag
     log_header = "Collecting data for EMS : [#{collector.manager.name}] id: [#{collector.manager.id}]"
     $azure_stack_log.info("#{log_header}...")
 
+    cloud_networks
+    network_ports
     security_groups
 
     $azure_stack_log.info("#{log_header}...Complete")
+  end
+
+  def cloud_networks
+    collector.networks.each do |network|
+      cloud_network = persister.cloud_networks.build(
+        :name    => network.name,
+        :ems_ref => network.id.downcase
+      )
+
+      cloud_subnets(network, cloud_network) if network.subnets
+    end
+  end
+
+  def cloud_subnets(network, cloud_network)
+    network.subnets.each do |subnet|
+      persister.cloud_subnets.build(
+        :name            => subnet.name,
+        :ems_ref         => subnet.id.downcase,
+        :cloud_network   => cloud_network,
+        :security_groups => build_security_groups(subnet)
+      )
+    end
+  end
+
+  def network_ports
+    collector.network_ports.each do |port|
+      persister.network_ports.build(
+        :name            => port.name,
+        :ems_ref         => port.id.downcase,
+        :mac_address     => port.mac_address,
+        :device          => persister.vms.lazy_find(port.virtual_machine&.id&.downcase),
+        :security_groups => build_security_groups(port)
+      )
+    end
+  end
+
+  # helper method that returns either an empty array or a one-element
+  # array containing the entity's security group.
+  def build_security_groups(entity)
+    security_groups = []
+    security_group_id = entity.network_security_group&.id&.downcase
+    if security_group_id
+      security_groups << persister.security_groups.lazy_find(security_group_id)
+    end
+
+    security_groups
   end
 
   def security_groups

--- a/app/models/manageiq/providers/azure_stack/inventory/persister/definitions/network_collections.rb
+++ b/app/models/manageiq/providers/azure_stack/inventory/persister/definitions/network_collections.rb
@@ -2,6 +2,18 @@ module ManageIQ::Providers::AzureStack::Inventory::Persister::Definitions::Netwo
   extend ActiveSupport::Concern
 
   def initialize_network_inventory_collections
-    add_collection(network, :security_groups)
+    %i[cloud_networks
+       cloud_subnets
+       network_ports
+       security_groups].each do |name|
+      add_collection(network, name)
+    end
+
+    add_collection(cloud, :vms) do |builder|
+      builder.add_properties(
+        :parent   => manager.parent_manager,
+        :strategy => :local_db_find_references
+      )
+    end
   end
 end

--- a/app/models/manageiq/providers/azure_stack/network_manager.rb
+++ b/app/models/manageiq/providers/azure_stack/network_manager.rb
@@ -1,6 +1,9 @@
 class ManageIQ::Providers::AzureStack::NetworkManager < ManageIQ::Providers::NetworkManager
   require_nested :RefreshWorker
   require_nested :Refresher
+  require_nested :CloudNetwork
+  require_nested :CloudSubnet
+  require_nested :NetworkPort
   require_nested :SecurityGroup
 
   delegate :authentication_check,

--- a/app/models/manageiq/providers/azure_stack/network_manager/cloud_network.rb
+++ b/app/models/manageiq/providers/azure_stack/network_manager/cloud_network.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::AzureStack::NetworkManager::CloudNetwork < ::CloudNetwork
+end

--- a/app/models/manageiq/providers/azure_stack/network_manager/cloud_subnet.rb
+++ b/app/models/manageiq/providers/azure_stack/network_manager/cloud_subnet.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::AzureStack::NetworkManager::CloudSubnet < ::CloudSubnet
+end

--- a/app/models/manageiq/providers/azure_stack/network_manager/network_port.rb
+++ b/app/models/manageiq/providers/azure_stack/network_manager/network_port.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::AzureStack::NetworkManager::NetworkPort < ::NetworkPort
+end

--- a/spec/models/manageiq/providers/azure_stack/cloud_manager/vcr_fixtures/full-refresh-deployment.json
+++ b/spec/models/manageiq/providers/azure_stack/cloud_manager/vcr_fixtures/full-refresh-deployment.json
@@ -100,6 +100,9 @@
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[variables('location')]",
+      "dependsOn": [
+        "[variables('networkSecurityGroupName')]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -110,7 +113,10 @@
           {
             "name": "[variables('subnetName')]",
             "properties": {
-              "addressPrefix": "[variables('subnetPrefix')]"
+              "addressPrefix": "[variables('subnetPrefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]

--- a/spec/vcr_cassettes/manageiq/providers/azure_stack/cloud_manager/refresher/V2017_03_09-network.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure_stack/cloud_manager/refresher/V2017_03_09-network.yml
@@ -2,6 +2,163 @@
 http_interactions:
 - request:
     method: get
+    uri: https://AZURE_STACK_HOST/subscriptions/AZURE_STACK_SUBSCRIPTION/providers/Microsoft.Network/virtualnetworks?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+        - Ruby/2.5.6 (x86_64-linux) ms_rest/0.7.4 ms_rest_azure/0.11.0 Azure-SDK-For-Ruby
+          azure_mgmt_network/0.18.2 Profiles/V2017_03_09/Network/Mgmt
+      Content-Type:
+        - application/json; charset=utf-8
+      Accept:
+        - application/json
+      Accept-Language:
+        - en-US
+      X-Ms-Client-Request-Id:
+        - ec397a3c-5892-4e84-a8e5-aa8eb201f62a
+      Authorization:
+        - Bearer AZURE_STACK_TOKEN
+      Accept-Encoding:
+        - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+        - no-cache
+      Pragma:
+        - no-cache
+      Content-Length:
+        - '1697'
+      Content-Type:
+        - application/json; charset=utf-8
+      Expires:
+        - "-1"
+      X-Ms-Correlation-Request-Id:
+        - 862b20b2-8f5a-44cc-9d5b-6c23b3c30016
+      X-Ms-Request-Id:
+        - 96083d15-0ceb-4a59-84f6-71c713feeaca
+      Server:
+        - Microsoft-HTTPAPI/2.0
+      Www-Authenticate:
+        - oYG3MIG0oAMKAQChCwYJKoZIgvcSAQICooGfBIGcYIGZBgkqhkiG9xIBAgICAG+BiTCBhqADAgEFoQMCAQ+iejB4oAMCARKicQRvJ+YbB6K9G3xP5RBWZjNO2h0xrGVQhSDb3oXD25uWWVPL+mJHR8O2em9YR5YB3yQgp8qVDTc48HbvYrjrF19VBkef1FtklbE+qrypdnEcnqMM5kE+L5v6kRgOuCK6Wx3Xy5vlitFx95yHuTFQV7XS
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+        - '14880'
+      X-Ms-Routing-Request-Id:
+        - WESTUS:20190920T071428Z:862b20b2-8f5a-44cc-9d5b-6c23b3c30016
+      Strict-Transport-Security:
+        - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+        - nosniff
+      Date:
+        - Fri, 20 Sep 2019 07:14:28 GMT
+    body:
+      encoding: UTF-8
+      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"demoNetwork\",\r\n
+      \     \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/virtualNetworks/demoNetwork\",\r\n
+      \     \"etag\": \"W/\\\"a3af24c6-ccb8-49c4-8b59-3b849a7d9247\\\"\",\r\n      \"type\":
+      \"Microsoft.Network/virtualNetworks\",\r\n      \"location\": \"westus\",\r\n
+      \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
+      \       \"resourceGuid\": \"8aa9a10b-026a-44ed-9ab8-4597fd1e7399\",\r\n        \"addressSpace\":
+      {\r\n          \"addressPrefixes\": [\r\n            \"10.0.0.0/24\"\r\n          ]\r\n
+      \       },\r\n        \"subnets\": [\r\n          {\r\n            \"name\":
+      \"demoSubnet\",\r\n            \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/virtualNetworks/demoNetwork/subnets/demoSubnet\",\r\n
+      \           \"etag\": \"W/\\\"a3af24c6-ccb8-49c4-8b59-3b849a7d9247\\\"\",\r\n
+      \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
+      \             \"addressPrefix\": \"10.0.0.0/24\",\r\n              \"networkSecurityGroup\":
+      {\r\n                \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkSecurityGroups/demoSecurityGroup\"\r\n
+      \             },\r\n              \"ipConfigurations\": [\r\n                {\r\n
+      \                 \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkInterfaces/demoNic0/ipConfigurations/ipconfig1\"\r\n
+      \               }\r\n              ]\r\n            },\r\n            \"type\":
+      \"Microsoft.Network/virtualNetworks/subnets\"\r\n          }\r\n        ]\r\n
+      \     }\r\n    }\r\n  ]\r\n}"
+    http_version:
+  recorded_at: Fri, 20 Sep 2019 07:14:28 GMT
+- request:
+    method: get
+    uri: https://AZURE_STACK_HOST/subscriptions/AZURE_STACK_SUBSCRIPTION/providers/Microsoft.Network/networkInterfaces?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+        - Ruby/2.5.6 (x86_64-linux) ms_rest/0.7.4 ms_rest_azure/0.11.0 Azure-SDK-For-Ruby
+          azure_mgmt_network/0.18.2 Profiles/V2017_03_09/Network/Mgmt
+      Content-Type:
+        - application/json; charset=utf-8
+      Accept:
+        - application/json
+      Accept-Language:
+        - en-US
+      X-Ms-Client-Request-Id:
+        - a57451ba-ed47-4986-a8c7-a514f44fbee9
+      Authorization:
+        - Bearer AZURE_STACK_TOKEN
+      Accept-Encoding:
+        - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+        - no-cache
+      Pragma:
+        - no-cache
+      Content-Length:
+        - '2025'
+      Content-Type:
+        - application/json; charset=utf-8
+      Expires:
+        - "-1"
+      X-Ms-Correlation-Request-Id:
+        - 97fee06f-b740-47fc-82ec-89b1201c70aa
+      X-Ms-Request-Id:
+        - af804954-aafc-4d9e-8405-4ed010414032
+      Server:
+        - Microsoft-HTTPAPI/2.0
+      Www-Authenticate:
+        - oYG3MIG0oAMKAQChCwYJKoZIgvcSAQICooGfBIGcYIGZBgkqhkiG9xIBAgICAG+BiTCBhqADAgEFoQMCAQ+iejB4oAMCARKicQRvculyW9cSHsVIXprf0aW10XqiWJKjBm/B4E2Re7ulL/u4SYfRz0A43oTu27709u8pKqVNX3ByglJ1iOkA/TeEfdOmO80QDV1umooA+zrhsJBbeZeLERULA4ypBW5Rq3NahG4Jg4RBCLH1pa0N4asI
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+        - '14989'
+      X-Ms-Routing-Request-Id:
+        - WESTUS:20190918T113234Z:97fee06f-b740-47fc-82ec-89b1201c70aa
+      Strict-Transport-Security:
+        - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+        - nosniff
+      Date:
+        - Wed, 18 Sep 2019 11:32:33 GMT
+    body:
+      encoding: UTF-8
+      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"demoNic0\",\r\n      \"id\":
+        \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkInterfaces/demoNic0\",\r\n
+        \     \"etag\": \"W/\\\"596998df-602c-4313-bbde-79398c9a3369\\\"\",\r\n      \"location\":
+        \"westus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
+        \       \"resourceGuid\": \"a5488730-5838-48df-b926-778b6033fa6a\",\r\n        \"ipConfigurations\":
+        [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
+        \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkInterfaces/demoNic0/ipConfigurations/ipconfig1\",\r\n
+        \           \"etag\": \"W/\\\"596998df-602c-4313-bbde-79398c9a3369\\\"\",\r\n
+        \           \"type\": \"Microsoft.Network/networkInterfaces/ipConfigurations\",\r\n
+        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
+        \             \"privateIPAddress\": \"10.0.0.4\",\r\n              \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n              \"subnet\": {\r\n                \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/virtualNetworks/demoNetwork/subnets/demoSubnet\"\r\n
+        \             },\r\n              \"primary\": true\r\n            }\r\n          }\r\n
+        \       ],\r\n        \"dnsSettings\": {\r\n          \"dnsServers\": [],\r\n
+        \         \"appliedDnsServers\": []\r\n        },\r\n        \"macAddress\":
+        \"001DD8B70047\",\r\n        \"enableIPForwarding\": false,\r\n        \"networkSecurityGroup\":
+        {\r\n          \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkSecurityGroups/demoSecurityGroup\"\r\n
+        \       },\r\n        \"primary\": true,\r\n        \"virtualMachine\": {\r\n
+        \         \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Compute/virtualMachines/demoVm\"\r\n
+        \       }\r\n      },\r\n      \"type\": \"Microsoft.Network/networkInterfaces\"\r\n
+        \   }\r\n  ]\r\n}"
+    http_version:
+  recorded_at: Wed, 18 Sep 2019 11:32:34 GMT
+- request:
+    method: get
     uri: https://AZURE_STACK_HOST/subscriptions/AZURE_STACK_SUBSCRIPTION/providers/Microsoft.Network/networkSecurityGroups?api-version=2015-06-15
     body:
       encoding: US-ASCII

--- a/spec/vcr_cassettes/manageiq/providers/azure_stack/cloud_manager/refresher/V2018_03_01-network.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure_stack/cloud_manager/refresher/V2018_03_01-network.yml
@@ -2,6 +2,166 @@
 http_interactions:
 - request:
     method: get
+    uri: https://AZURE_STACK_HOST/subscriptions/AZURE_STACK_SUBSCRIPTION/providers/Microsoft.Network/virtualNetworks?api-version=2017-10-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+        - Ruby/2.5.6 (x86_64-linux) ms_rest/0.7.4 ms_rest_azure/0.11.0 Azure-SDK-For-Ruby
+          azure_mgmt_network/0.18.2 Profiles/V2018_03_01/Network/Mgmt
+      Content-Type:
+        - application/json; charset=utf-8
+      Accept:
+        - application/json
+      Accept-Language:
+        - en-US
+      X-Ms-Client-Request-Id:
+        - be8bcce2-85f6-4f4f-93bd-d087858cbec9
+      Authorization:
+        - Bearer AZURE_STACK_TOKEN
+      Accept-Encoding:
+        - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+        - no-cache
+      Pragma:
+        - no-cache
+      Content-Length:
+        - '1814'
+      Content-Type:
+        - application/json; charset=utf-8
+      Expires:
+        - "-1"
+      X-Ms-Correlation-Request-Id:
+        - 5175d0ad-d823-4060-bd40-516913c1cbd8
+      X-Ms-Request-Id:
+        - 588f8888-3452-43eb-9831-493235804164
+      Server:
+        - Microsoft-HTTPAPI/2.0
+      Www-Authenticate:
+        - oYG3MIG0oAMKAQChCwYJKoZIgvcSAQICooGfBIGcYIGZBgkqhkiG9xIBAgICAG+BiTCBhqADAgEFoQMCAQ+iejB4oAMCARKicQRvYtPMdiYZPUn+SSeXyG+J3H7q2XPHF55zz+CYf1Ecsh3ItGpKoXP7wp/tL/wqJOfjuNMxMQQ45/0pajno7se08H/83vxuQFI6KnYykAHwodMuHE9H6wYr3k6kUg5H/M8nLOvGhQLrD5E8TFV2h3ff
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+        - '14877'
+      X-Ms-Routing-Request-Id:
+        - WESTUS:20190920T071433Z:5175d0ad-d823-4060-bd40-516913c1cbd8
+      Strict-Transport-Security:
+        - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+        - nosniff
+      Date:
+        - Fri, 20 Sep 2019 07:14:33 GMT
+    body:
+      encoding: UTF-8
+      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"demoNetwork\",\r\n
+      \     \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/virtualNetworks/demoNetwork\",\r\n
+      \     \"etag\": \"W/\\\"a3af24c6-ccb8-49c4-8b59-3b849a7d9247\\\"\",\r\n      \"type\":
+      \"Microsoft.Network/virtualNetworks\",\r\n      \"location\": \"westus\",\r\n
+      \     \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
+      \       \"resourceGuid\": \"8aa9a10b-026a-44ed-9ab8-4597fd1e7399\",\r\n        \"addressSpace\":
+      {\r\n          \"addressPrefixes\": [\r\n            \"10.0.0.0/24\"\r\n          ]\r\n
+      \       },\r\n        \"subnets\": [\r\n          {\r\n            \"name\":
+      \"demoSubnet\",\r\n            \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/virtualNetworks/demoNetwork/subnets/demoSubnet\",\r\n
+      \           \"etag\": \"W/\\\"a3af24c6-ccb8-49c4-8b59-3b849a7d9247\\\"\",\r\n
+      \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
+      \             \"addressPrefix\": \"10.0.0.0/24\",\r\n              \"networkSecurityGroup\":
+      {\r\n                \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkSecurityGroups/demoSecurityGroup\"\r\n
+      \             },\r\n              \"ipConfigurations\": [\r\n                {\r\n
+      \                 \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkInterfaces/demoNic0/ipConfigurations/ipconfig1\"\r\n
+      \               }\r\n              ]\r\n            },\r\n            \"type\":
+      \"Microsoft.Network/virtualNetworks/subnets\"\r\n          }\r\n        ],\r\n
+      \       \"virtualNetworkPeerings\": [],\r\n        \"enableDdosProtection\":
+      false,\r\n        \"enableVmProtection\": false\r\n      }\r\n    }\r\n  ]\r\n}"
+    http_version:
+  recorded_at: Fri, 20 Sep 2019 07:14:33 GMT
+- request:
+    method: get
+    uri: https://AZURE_STACK_HOST/subscriptions/AZURE_STACK_SUBSCRIPTION/providers/Microsoft.Network/networkInterfaces?api-version=2017-10-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+        - Ruby/2.5.6 (x86_64-linux) ms_rest/0.7.4 ms_rest_azure/0.11.0 Azure-SDK-For-Ruby
+          azure_mgmt_network/0.18.2 Profiles/V2018_03_01/Network/Mgmt
+      Content-Type:
+        - application/json; charset=utf-8
+      Accept:
+        - application/json
+      Accept-Language:
+        - en-US
+      X-Ms-Client-Request-Id:
+        - 249657c9-88f1-4d65-a189-11c0d9d48df1
+      Authorization:
+        - Bearer AZURE_STACK_TOKEN
+      Accept-Encoding:
+        - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+        - no-cache
+      Pragma:
+        - no-cache
+      Content-Length:
+        - '2218'
+      Content-Type:
+        - application/json; charset=utf-8
+      Expires:
+        - "-1"
+      X-Ms-Correlation-Request-Id:
+        - 43b1d66e-bcb0-4378-82fa-e7a154f12cf6
+      X-Ms-Request-Id:
+        - e02b2299-afcb-450c-b908-061ba00795a8
+      Server:
+        - Microsoft-HTTPAPI/2.0
+      Www-Authenticate:
+        - oYG3MIG0oAMKAQChCwYJKoZIgvcSAQICooGfBIGcYIGZBgkqhkiG9xIBAgICAG+BiTCBhqADAgEFoQMCAQ+iejB4oAMCARKicQRvoXCJ+EDXF0wfOtrNTUcbdHSCPUwhE4aLMrJ0+EVYqOaqknONsXcgGgzk9goX+JDgilo0/zFTHijHzb1O5czlOFczCYuudAzhsFP+U4LUdt+jxWLfi062va61v42JWqIZ8JRQ62ntrCksGKDV++O+
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+        - '14986'
+      X-Ms-Routing-Request-Id:
+        - WESTUS:20190918T113239Z:43b1d66e-bcb0-4378-82fa-e7a154f12cf6
+      Strict-Transport-Security:
+        - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+        - nosniff
+      Date:
+        - Wed, 18 Sep 2019 11:32:38 GMT
+    body:
+      encoding: UTF-8
+      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"demoNic0\",\r\n      \"id\":
+        \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkInterfaces/demoNic0\",\r\n
+        \     \"etag\": \"W/\\\"596998df-602c-4313-bbde-79398c9a3369\\\"\",\r\n      \"location\":
+        \"westus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n
+        \       \"resourceGuid\": \"a5488730-5838-48df-b926-778b6033fa6a\",\r\n        \"ipConfigurations\":
+        [\r\n          {\r\n            \"name\": \"ipconfig1\",\r\n            \"id\":
+        \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkInterfaces/demoNic0/ipConfigurations/ipconfig1\",\r\n
+        \           \"etag\": \"W/\\\"596998df-602c-4313-bbde-79398c9a3369\\\"\",\r\n
+        \           \"type\": \"Microsoft.Network/networkInterfaces/ipConfigurations\",\r\n
+        \           \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n
+        \             \"privateIPAddress\": \"10.0.0.4\",\r\n              \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n              \"subnet\": {\r\n                \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/virtualNetworks/demoNetwork/subnets/demoSubnet\"\r\n
+        \             },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\":
+        \"IPv4\"\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\":
+        {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": [],\r\n
+        \         \"internalDomainNameSuffix\": \"gg1gci4luxju3k2iktl1tgwbtc.a--x.internal.cloudapp.net\"\r\n
+        \       },\r\n        \"macAddress\": \"001DD8B70047\",\r\n        \"enableAcceleratedNetworking\":
+        false,\r\n        \"enableIPForwarding\": false,\r\n        \"networkSecurityGroup\":
+        {\r\n          \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkSecurityGroups/demoSecurityGroup\"\r\n
+        \       },\r\n        \"primary\": true,\r\n        \"virtualMachine\": {\r\n
+        \         \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Compute/virtualMachines/demoVm\"\r\n
+        \       }\r\n      },\r\n      \"type\": \"Microsoft.Network/networkInterfaces\"\r\n
+        \   }\r\n  ]\r\n}"
+    http_version:
+  recorded_at: Wed, 18 Sep 2019 11:32:39 GMT
+- request:
+    method: get
     uri: https://AZURE_STACK_HOST/subscriptions/AZURE_STACK_SUBSCRIPTION/providers/Microsoft.Network/networkSecurityGroups?api-version=2017-10-01
     body:
       encoding: US-ASCII


### PR DESCRIPTION
So far the provider's `NetworkManager` inventory supported only security groups. 

With this commit we extend the `NetworkManager` inventory with cloud networks, cloud subnets and network ports. Cloud subnets and network ports are connected to security groups, while network
ports are in addition connected to VMs.