### PR TITLE
Versioned CloudManager and NetworkManager collectors

### DIFF
--- a/app/models/manageiq/providers/azure_stack/inventory.rb
+++ b/app/models/manageiq/providers/azure_stack/inventory.rb
@@ -8,4 +8,12 @@ class ManageIQ::Providers::AzureStack::Inventory < ManageIQ::Providers::Inventor
   def self.default_manager_name
     'CloudManager'
   end
+
+  # Sets the appropriate class of versioned collector for
+  # CloudManager and NetworkManager targets
+  def self.collector_class_for(ems, target = nil, manager_name = nil)
+    target = ems if target.nil?
+    manager_name = "#{target.class.name.demodulize}::#{ems.api_version}" if manager_name.nil?
+    class_for(ems, target, 'Collector', manager_name)
+  end
 end

--- a/app/models/manageiq/providers/azure_stack/inventory/collector/cloud_manager/v2017_03_09.rb
+++ b/app/models/manageiq/providers/azure_stack/inventory/collector/cloud_manager/v2017_03_09.rb
@@ -1,0 +1,22 @@
+# rubocop:disable Naming/ClassAndModuleCamelCase
+class ManageIQ::Providers::AzureStack::Inventory::Collector::CloudManager::V2017_03_09 < ManageIQ::Providers::AzureStack::Inventory::Collector::CloudManager
+  def vms
+    $azure_stack_log.debug("Fetching VM ids, then fetching full data for each")
+    azure_resources.resources.list(:filter => "resourceType eq 'Microsoft.Compute/virtualMachines'").map do |vm|
+      azure_compute.virtual_machines.get(resource_group_name(vm.id), vm.name, :expand => 'instanceView')
+    end
+  end
+
+  def orchestration_stacks
+    resource_groups.flat_map do |group|
+      azure_resources.deployments.list(group.name).map do |deployment|
+        [
+          group,                                                                   # resource group
+          deployment,                                                              # deployment
+          azure_resources.deployment_operations.list(group.name, deployment.name)  # operations of the deployment
+        ]
+      end
+    end
+  end
+end
+# rubocop:enable Naming/ClassAndModuleCamelCase

--- a/app/models/manageiq/providers/azure_stack/inventory/collector/cloud_manager/v2018_03_01.rb
+++ b/app/models/manageiq/providers/azure_stack/inventory/collector/cloud_manager/v2018_03_01.rb
@@ -1,0 +1,4 @@
+# rubocop:disable Naming/ClassAndModuleCamelCase
+class ManageIQ::Providers::AzureStack::Inventory::Collector::CloudManager::V2018_03_01 < ManageIQ::Providers::AzureStack::Inventory::Collector::CloudManager
+end
+# rubocop:enable Naming/ClassAndModuleCamelCase

--- a/app/models/manageiq/providers/azure_stack/inventory/collector/network_manager.rb
+++ b/app/models/manageiq/providers/azure_stack/inventory/collector/network_manager.rb
@@ -1,4 +1,9 @@
+# This class contains a reference implementation of collector for NetworkManager.
+# The methods implemented here are completely aligned with the V2018_03_01 version profile.
 class ManageIQ::Providers::AzureStack::Inventory::Collector::NetworkManager < ManageIQ::Providers::AzureStack::Inventory::Collector
+  require_nested :V2018_03_01
+  require_nested :V2017_03_09
+
   def networks
     azure_network.virtual_networks.list_all
   end

--- a/app/models/manageiq/providers/azure_stack/inventory/collector/network_manager/v2017_03_09.rb
+++ b/app/models/manageiq/providers/azure_stack/inventory/collector/network_manager/v2017_03_09.rb
@@ -1,0 +1,4 @@
+# rubocop:disable Naming/ClassAndModuleCamelCase
+class ManageIQ::Providers::AzureStack::Inventory::Collector::NetworkManager::V2017_03_09 < ManageIQ::Providers::AzureStack::Inventory::Collector::NetworkManager
+end
+# rubocop:enable Naming/ClassAndModuleCamelCase

--- a/app/models/manageiq/providers/azure_stack/inventory/collector/network_manager/v2018_03_01.rb
+++ b/app/models/manageiq/providers/azure_stack/inventory/collector/network_manager/v2018_03_01.rb
@@ -1,0 +1,4 @@
+# rubocop:disable Naming/ClassAndModuleCamelCase
+class ManageIQ::Providers::AzureStack::Inventory::Collector::NetworkManager::V2018_03_01 < ManageIQ::Providers::AzureStack::Inventory::Collector::NetworkManager
+end
+# rubocop:enable Naming/ClassAndModuleCamelCase

--- a/app/models/manageiq/providers/azure_stack/network_manager.rb
+++ b/app/models/manageiq/providers/azure_stack/network_manager.rb
@@ -6,7 +6,8 @@ class ManageIQ::Providers::AzureStack::NetworkManager < ManageIQ::Providers::Net
   require_nested :NetworkPort
   require_nested :SecurityGroup
 
-  delegate :authentication_check,
+  delegate :api_version,
+           :authentication_check,
            :authentication_status,
            :authentication_status_ok?,
            :authentications,

--- a/spec/vcr_cassettes/manageiq/providers/azure_stack/cloud_manager/refresher/V2018_03_01.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure_stack/cloud_manager/refresher/V2018_03_01.yml
@@ -330,63 +330,7 @@ http_interactions:
   recorded_at: Fri, 07 Jun 2019 08:59:14 GMT
 - request:
     method: get
-    uri: https://AZURE_STACK_HOST/subscriptions/AZURE_STACK_SUBSCRIPTION/resources?$filter=resourceType%20eq%20%27Microsoft.Compute/virtualMachines%27&api-version=2018-02-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Ruby/2.4.6 (x86_64-linux) ms_rest/0.7.4 ms_rest_azure/0.11.0 Azure-SDK-For-Ruby
-        azure_mgmt_resources/0.17.2 Profiles/V2018_03_01/Resources/Mgmt
-      Content-Type:
-      - application/json; charset=utf-8
-      Accept:
-      - application/json
-      Accept-Language:
-      - en-US
-      X-Ms-Client-Request-Id:
-      - ae7486ef-53d5-49fa-b552-51ae468c9e4b
-      Authorization:
-      - Bearer AZURE_STACK_TOKEN
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Request-Id:
-      - 0ffa79b8-7e72-4c05-a54b-0af2938bd246
-      X-Ms-Correlation-Request-Id:
-      - 0ffa79b8-7e72-4c05-a54b-0af2938bd246
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20190607T085759Z:0ffa79b8-7e72-4c05-a54b-0af2938bd246
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Fri, 07 Jun 2019 08:57:59 GMT
-      Content-Length:
-      - '237'
-    body:
-      encoding: UTF-8
-      string: '{"value":[{"id":"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Compute/virtualMachines/demoVm","name":"demoVm","type":"Microsoft.Compute/virtualMachines","location":"westus"}]}'
-    http_version: 
-  recorded_at: Fri, 07 Jun 2019 08:59:15 GMT
-- request:
-    method: get
-    uri: https://AZURE_STACK_HOST/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Compute/virtualMachines/demoVm?$expand=instanceView&api-version=2017-03-30
+    uri: https://AZURE_STACK_HOST/subscriptions/AZURE_STACK_SUBSCRIPTION/providers/Microsoft.Compute/virtualMachines?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -401,7 +345,7 @@ http_interactions:
       Accept-Language:
       - en-US
       X-Ms-Client-Request-Id:
-      - 13e3f87d-0122-417d-bb29-f23fdd7fd22b
+      - d96156aa-f479-412a-9b1a-65dd8344ff44
       Authorization:
       - Bearer AZURE_STACK_TOKEN
       Accept-Encoding:
@@ -416,7 +360,7 @@ http_interactions:
       Pragma:
       - no-cache
       Content-Length:
-      - '3317'
+      - '1750'
       Content-Type:
       - application/json; charset=utf-8
       Expires:
@@ -426,62 +370,125 @@ http_interactions:
       X-Ms-Served-By:
       - 00000000-0000-0000-0000-000000000000_0
       X-Ms-Correlation-Request-Id:
-      - 4e804275-2ea6-4943-a062-3171538af50d
+      - d83655f1-1183-4f36-b6c0-efeaf095ab2e
       Server:
       - Microsoft-HTTPAPI/2.0
       Www-Authenticate:
-      - oYG3MIG0oAMKAQChCwYJKoZIgvcSAQICooGfBIGcYIGZBgkqhkiG9xIBAgICAG+BiTCBhqADAgEFoQMCAQ+iejB4oAMCARKicQRv6N0qgwe9ruZIktMuGFYwABdz7oOpraysDUKKVKyyT63jbF57WJidc1y3+XzwctpBq9xfTuqt4792ptJdwOhRciL7qEOUAepAmq7r+TWGqrUvpxW8g1CaGqlQyrj2cpyYi9seH62KBh1sjYv+bHxc
+      - oYG3MIG0oAMKAQChCwYJKoZIgvcSAQICooGfBIGcYIGZBgkqhkiG9xIBAgICAG+BiTCBhqADAgEFoQMCAQ+iejB4oAMCARKicQRv5uB6FuLYr4yxA8K+jiGVgYno6BdR9KvBr1l3oGbyoCG97lNcDseSq3WjA0kXouesPL8rCTy8ZB4oWcJ7n9+Yh3J+g3UQ7LLf8anfVDtWIr2C3ulk6zLufxXC7N46SZsIWuIuKk9Y1B7voWSjKgI+
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
+      - '14831'
       X-Ms-Request-Id:
-      - 4e804275-2ea6-4943-a062-3171538af50d
+      - d83655f1-1183-4f36-b6c0-efeaf095ab2e
       X-Ms-Routing-Request-Id:
-      - WESTUS:20190607T085800Z:4e804275-2ea6-4943-a062-3171538af50d
+      - WESTUS:20190927T060241Z:d83655f1-1183-4f36-b6c0-efeaf095ab2e
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Fri, 07 Jun 2019 08:57:59 GMT
+      - Fri, 27 Sep 2019 06:02:41 GMT
     body:
       encoding: UTF-8
-      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"adbd038a-aa9d-4145-b5b6-eaa5dfe76a7c\",\r\n
-        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_A1\"\r\n    },\r\n
-        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
-        \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\":
-        {\r\n        \"osType\": \"Linux\",\r\n        \"name\": \"osdisk\",\r\n        \"createOption\":
-        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://demostorageaccount.blob.westus.AZURE_STACK_DOMAIN/vhds/osdisk.vhd\"\r\n
-        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
-        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"demoVm\",\r\n
-        \     \"adminUsername\": \"demoUsername\",\r\n      \"linuxConfiguration\":
-        {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\":
-        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkInterfaces/demoNic0\"}]},\r\n
-        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
-        true,\r\n        \"storageUri\": \"https://demostorageaccount.blob.westus.AZURE_STACK_DOMAIN/\"\r\n
-        \     }\r\n    },\r\n    \"provisioningState\": \"Failed\",\r\n    \"instanceView\":
-        {\r\n      \"rdpThumbPrint\": \"SHA2565VQmHkpw0l6AXXK2KWJVMVxmkO3kzsyAqWd9RVUsPj8\",\r\n
-        \     \"vmAgent\": {\r\n        \"vmAgentVersion\": \"2.2.35.1\",\r\n        \"statuses\":
-        [\r\n          {\r\n            \"code\": \"ProvisioningState/Succeeded\",\r\n
-        \           \"level\": \"Info\",\r\n            \"displayStatus\": \"Ready\",\r\n
-        \           \"message\": \"Guest Agent is running\",\r\n            \"time\":
-        \"2019-06-07T08:58:00+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\":
-        []\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"osdisk\",\r\n
-        \         \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/Succeeded\",\r\n
-        \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
-        Succeeded\",\r\n              \"time\": \"2019-01-08T15:29:36.6601291+00:00\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"bootDiagnostics\":
-        {\r\n        \"consoleScreenshotBlobUri\": \"https://demostorageaccount.blob.westus.AZURE_STACK_DOMAIN/bootdiagnostics-demovm-adbd038a-aa9d-4145-b5b6-eaa5dfe76a7c/demoVm.adbd038a-aa9d-4145-b5b6-eaa5dfe76a7c.screenshot.bmp\",\r\n
-        \       \"serialConsoleLogBlobUri\": \"https://demostorageaccount.blob.westus.AZURE_STACK_DOMAIN/bootdiagnostics-demovm-adbd038a-aa9d-4145-b5b6-eaa5dfe76a7c/demoVm.adbd038a-aa9d-4145-b5b6-eaa5dfe76a7c.serialconsole.log\"\r\n
-        \     },\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/failed/InternalExecutionError/osProvisioningComplete\",\r\n
-        \         \"level\": \"Error\",\r\n          \"displayStatus\": \"OS provisioning
-        complete\",\r\n          \"message\": \"Failed to achieve desired power state
-        'PoweredOff' for VM 'demoVm'\",\r\n          \"time\": \"2019-01-11T14:57:23.8444628+00:00\"\r\n
-        \       },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n
-        \       }\r\n      ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
-        \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Compute/virtualMachines/demoVm\",\r\n
-        \ \"name\": \"demoVm\"\r\n}"
-    http_version: 
-  recorded_at: Fri, 07 Jun 2019 08:59:16 GMT
+      string: "{\r\n  \"value\": [\r\n    {\r\n      \"properties\": {\r\n        \"vmId\":
+        \"bbb63335-1cde-4a3d-a805-8032670929c9\",\r\n        \"hardwareProfile\":
+        {\r\n          \"vmSize\": \"Standard_A1\"\r\n        },\r\n        \"storageProfile\":
+        {\r\n          \"imageReference\": {\r\n            \"publisher\": \"Canonical\",\r\n
+        \           \"offer\": \"UbuntuServer\",\r\n            \"sku\": \"16.04-LTS\",\r\n
+        \           \"version\": \"latest\"\r\n          },\r\n          \"osDisk\":
+        {\r\n            \"osType\": \"Linux\",\r\n            \"name\": \"osdisk\",\r\n
+        \           \"createOption\": \"FromImage\",\r\n            \"vhd\": {\r\n
+        \             \"uri\": \"https://demostorageaccount.blob.westus.stackpoc.com/vhds/osdisk.vhd\"\r\n
+        \           },\r\n            \"caching\": \"ReadWrite\",\r\n            \"diskSizeGB\":
+        30\r\n          },\r\n          \"dataDisks\": []\r\n        },\r\n        \"osProfile\":
+        {\r\n          \"computerName\": \"demoVm\",\r\n          \"adminUsername\":
+        \"demoUsername\",\r\n          \"linuxConfiguration\": {\r\n            \"disablePasswordAuthentication\":
+        false\r\n          },\r\n          \"secrets\": []\r\n        },\r\n        \"networkProfile\":
+        {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkInterfaces/demoNic0\"}]},\r\n
+        \       \"diagnosticsProfile\": {\r\n          \"bootDiagnostics\": {\r\n
+        \           \"enabled\": true,\r\n            \"storageUri\": \"https://demostorageaccount.blob.westus.stackpoc.com/\"\r\n
+        \         }\r\n        },\r\n        \"provisioningState\": \"Succeeded\"\r\n
+        \     },\r\n      \"type\": \"Microsoft.Compute/virtualMachines\",\r\n      \"location\":
+        \"westus\",\r\n      \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/DEMO-RESOURCE-GROUP/providers/Microsoft.Compute/virtualMachines/demoVm\",\r\n
+        \     \"name\": \"demoVm\"\r\n    }\r\n  ]\r\n}"
+    http_version:
+  recorded_at: Fri, 27 Sep 2019 06:02:41 GMT
+- request:
+    method: get
+    uri: https://AZURE_STACK_HOST/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Compute/virtualMachines/demoVm/instanceView?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.4.6 (x86_64-linux) ms_rest/0.7.4 ms_rest_azure/0.11.0 Azure-SDK-For-Ruby
+        azure_mgmt_compute/0.18.3 Profiles/V2018_03_01/Compute/Mgmt
+      Content-Type:
+      - application/json; charset=utf-8
+      Accept:
+      - application/json
+      Accept-Language:
+      - en-US
+      X-Ms-Client-Request-Id:
+      - '0080b4c7-ebe9-4559-a373-fecb3c286ea8'
+      Authorization:
+      - Bearer AZURE_STACK_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '1498'
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 00000000-0000-0000-0000-000000000000_0
+      X-Ms-Correlation-Request-Id:
+      - fbb43540-5e92-47a8-a749-017447a06e02
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Www-Authenticate:
+      - oYG3MIG0oAMKAQChCwYJKoZIgvcSAQICooGfBIGcYIGZBgkqhkiG9xIBAgICAG+BiTCBhqADAgEFoQMCAQ+iejB4oAMCARKicQRvOOU5Z7yUunqS6D+M2JVptx5/E7dUsDyu75K/P/1qvgTu3kfvaNmVPxp+BdoTHwEOCrP+LnlCH+7Qgr5JiKSeokuC/JActHYO4V2n6gQd5CVMkN6zwfKG0nsA43Cqdkk/oNGOx9JdXWdnUOvRgIE3
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14830'
+      X-Ms-Request-Id:
+      - fbb43540-5e92-47a8-a749-017447a06e02
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20190927T060243Z:fbb43540-5e92-47a8-a749-017447a06e02
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Fri, 27 Sep 2019 06:02:43 GMT
+    body:
+      encoding: UTF-8
+      string: "{\r\n  \"rdpThumbPrint\": \"SHA2561rzyTWuCzcvUBomEkPl8mmiNjA2uKTJM3JLqUeop8GA\",\r\n
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"2.2.38.0\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Succeeded\",\r\n        \"level\":
+        \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n        \"message\":
+        \"Guest Agent is running\",\r\n        \"time\": \"2019-09-27T06:02:43+00:00\"\r\n
+        \     }\r\n    ],\r\n    \"extensionHandlers\": []\r\n  },\r\n  \"disks\":
+        [\r\n    {\r\n      \"name\": \"osdisk\",\r\n      \"statuses\": [\r\n        {\r\n
+        \         \"code\": \"ProvisioningState/Succeeded\",\r\n          \"level\":
+        \"Info\",\r\n          \"displayStatus\": \"Provisioning Succeeded\",\r\n
+        \         \"time\": \"2019-09-27T05:44:51.9915138+00:00\"\r\n        }\r\n
+        \     ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://demostorageaccount.blob.westus.stackpoc.com/bootdiagnostics-demovm-bbb63335-1cde-4a3d-a805-8032670929c9/demoVm.bbb63335-1cde-4a3d-a805-8032670929c9.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://demostorageaccount.blob.westus.stackpoc.com/bootdiagnostics-demovm-bbb63335-1cde-4a3d-a805-8032670929c9/demoVm.bbb63335-1cde-4a3d-a805-8032670929c9.serialconsole.log\"\r\n
+        \ },\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/Succeeded/osProvisioningComplete\",\r\n
+        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"OS provisioning complete\",\r\n
+        \     \"time\": \"2019-09-27T05:49:17.2926298+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/running\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM running\"\r\n    }\r\n  ]\r\n}"
+    http_version:
+  recorded_at: Fri, 27 Sep 2019 06:02:44 GMT
 - request:
     method: get
     uri: https://AZURE_STACK_HOST/subscriptions/AZURE_STACK_SUBSCRIPTION/resourcegroups/demo-resource-group/providers/Microsoft.Resources/deployments/?api-version=2018-02-01


### PR DESCRIPTION
This is a refactoring PR that introduces two subclasses for both collectors, i.e.  for `CloudManager` and `NetworkManager`. Specifically, we now have two versions of  each collector, corresponding to the two version profiles supported in this provider:
* `ManageIQ::Providers::AzureStack::Inventory::Collector::CloudManager::V2017_03_09`,
* `ManageIQ::Providers::AzureStack::Inventory::Collector::CloudManager::V2018_03_01`, and
* `ManageIQ::Providers::AzureStack::Inventory::Collector::NetworkManager::V2017_03_09`,
* `ManageIQ::Providers::AzureStack::Inventory::Collector::NetworkManager::V2018_03_01`.

#### Motivation
Our AzureStack provider currently supports two different API version profiles.  We rely on the official `azure-sdk-for-ruby` which also supports profiles. Depending on the selected version profile however, the clients for accessing AzureStack resources from `azure-sdk-for-ruby` may or may not have specific methods available. This results in collector methods doing checks like:

```ruby
# app/models/manageiq/providers/azure_stack/inventory/collector/cloud_manager.rb
def vms
    if azure_compute.virtual_machines.respond_to?(:instance_view) # Profile V2018_03_01
      ... # use the available method
    else  # Profile V2017_03_09
      ... # use some other method
    end
end

def orchestration_stacks
  # Old API names it 'list', recent versions name it 'list_by_resource_group'
  meth = azure_resources.deployments.respond_to?(:list_by_resource_group) ? :list_by_resource_group : :list
  azure_resources.deployments.send(meth, group.name).map do |deployment| 
  ...
  end
end
```

Even with only two version profiles, these checks feel awkward and harder to manage than necessary (unless you can reliably keep track of which methods exist in which profile). In addition, keeping track of these things is also quite error prone - please see below the related bug that was uncovered as a part of this refactoring.

Since our plan is to extend the inventory with target collection and hopefully support additional version profiles in the future, the number of these checks in collector methods will grow, so it feels like the right time to do something about it.

#### The approach
We kept the collector methods for the latest version profile we currently support (_V2018_03_01_) in the existing `Collector::CloudManager` and `Collector::NetworkManager` classes. For each manager, we added two subclasses named after profiles. These implement collector methods that differ from implementation in the parent classes (resulting in empty `Collector::CloudManager::V2018_03_01` and `Collector::NetworkManager::V2018_03_01`). 

Note that both subclasses of `NetworkManager` are currently empty, as all the collector methods implemented so far are common for both profiles.

To ensure that the appropriate collector subclasses are constructed for `CloudManager` and `NetworkManager` targets, we override `Inventory`'s `collector_class_for` method.

#### Side effects - bugfix
This refactoring uncovered a bug in the implementation of the current `vms` method on the `ManageIQ::Providers::AzureStack::Inventory::Collector::CloudManager` class. The happy path of the `if` block was never executed due to the erroneous condition (`azure_compute.respond_to?(:instance_view)` instead of `azure_compute.virtual_machines.respond_to?(:instance_view)`) which always evaluated to `false`. This resulted in the `vms` method making a suboptimal sequence of API calls for the `V2018_03_01` version profile.

After the refactoring described here, the `.respond_to()` check was not needed anymore and the desired sequence of calls got executed, however the `refresher_spec` test failed as the VCR cassette did not contain the recordings of these requests. 

The VCR cassette was updated to make tests green.

### Future work
