### PR TITLE
NetworkManager parser sets resource group for networks, network ports and security groups

### DIFF
--- a/app/models/manageiq/providers/azure_stack/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/azure_stack/inventory/parser/network_manager.rb
@@ -13,8 +13,9 @@ class ManageIQ::Providers::AzureStack::Inventory::Parser::NetworkManager < Manag
   def cloud_networks
     collector.networks.each do |network|
       cloud_network = persister.cloud_networks.build(
-        :name    => network.name,
-        :ems_ref => network.id.downcase
+        :name           => network.name,
+        :ems_ref        => network.id.downcase,
+        :resource_group => persister.resource_groups.lazy_find(collector.resource_group_id(network.id))
       )
 
       cloud_subnets(network, cloud_network) if network.subnets
@@ -37,6 +38,7 @@ class ManageIQ::Providers::AzureStack::Inventory::Parser::NetworkManager < Manag
       persister.network_ports.build(
         :name            => port.name,
         :ems_ref         => port.id.downcase,
+        :resource_group  => persister.resource_groups.lazy_find(collector.resource_group_id(port.id)),
         :mac_address     => port.mac_address,
         :device          => persister.vms.lazy_find(port.virtual_machine&.id&.downcase),
         :security_groups => build_security_groups(port)
@@ -59,8 +61,9 @@ class ManageIQ::Providers::AzureStack::Inventory::Parser::NetworkManager < Manag
   def security_groups
     collector.security_groups.each do |security_group|
       persister.security_groups.build(
-        :name    => security_group.name,
-        :ems_ref => security_group.id.downcase
+        :name           => security_group.name,
+        :ems_ref        => security_group.id.downcase,
+        :resource_group => persister.resource_groups.lazy_find(collector.resource_group_id(security_group.id))
       )
     end
   end

--- a/app/models/manageiq/providers/azure_stack/inventory/persister/definitions/network_collections.rb
+++ b/app/models/manageiq/providers/azure_stack/inventory/persister/definitions/network_collections.rb
@@ -9,11 +9,18 @@ module ManageIQ::Providers::AzureStack::Inventory::Persister::Definitions::Netwo
       add_collection(network, name)
     end
 
-    add_collection(cloud, :vms) do |builder|
-      builder.add_properties(
-        :parent   => manager.parent_manager,
-        :strategy => :local_db_find_references
-      )
+    add_related_cloud_collections
+  end
+
+  def add_related_cloud_collections
+    %i[resource_groups
+       vms].each do |name|
+      add_collection(cloud, name) do |builder|
+        builder.add_properties(
+          :parent   => manager.parent_manager,
+          :strategy => :local_db_find_references
+        )
+      end
     end
   end
 end

--- a/spec/models/manageiq/providers/azure_stack/cloud_manager/vcr_specs/refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure_stack/cloud_manager/vcr_specs/refresher_spec.rb
@@ -156,6 +156,7 @@ describe ManageIQ::Providers::AzureStack::CloudManager::Refresher do
   def assert_specific_network
     expect(network).not_to be_nil
     expect(ems_ref_suffix(network.ems_ref)).to match(%r{^/providers/microsoft.network/virtualnetworks/[^/]+$})
+    expect(network.resource_group).to eq(resource_group)
 
     expect(network.cloud_subnets).not_to be_nil
     expect(network.cloud_subnets.size).to eq(1)
@@ -173,9 +174,11 @@ describe ManageIQ::Providers::AzureStack::CloudManager::Refresher do
   def assert_specific_network_port
     expect(network_port).not_to be_nil
     expect(ems_ref_suffix(network_port.ems_ref)).to match(%r{^/providers/microsoft.network/networkinterfaces/[^/]+$})
-    expect(network_port.mac_address).to eq('001DD8B70047')
-
-    expect(network_port.device).to eq(vm)
+    expect(network_port).to have_attributes(
+      :resource_group => resource_group,
+      :mac_address    => '001DD8B70047',
+      :device         => vm
+    )
 
     assert_security_groups_binding(network_port)
   end
@@ -189,5 +192,6 @@ describe ManageIQ::Providers::AzureStack::CloudManager::Refresher do
   def assert_security_group
     expect(security_group).not_to be_nil
     expect(ems_ref_suffix(security_group.ems_ref)).to match(%r{^/providers/microsoft.network/networksecuritygroups/[^/]+$})
+    expect(security_group.resource_group).to eq(resource_group)
   end
 end


### PR DESCRIPTION
In this PR we update the inventory parser for `NetworkManager` so that when a `CloudNetwork`, `NetworkPort` or `SecurityGroup` is built, it is associated with the appropriate `ResourceGroup`.

@miq-bot add_label enhancement
@miq-bot assign @agrare 