### PR TITLE
Targeted refresh for ResourceGroup

### DIFF
--- a/app/models/manageiq/providers/azure_stack/ems_ref_mixin.rb
+++ b/app/models/manageiq/providers/azure_stack/ems_ref_mixin.rb
@@ -2,7 +2,7 @@ module ManageIQ::Providers::AzureStack::EmsRefMixin
   extend ActiveSupport::Concern
 
   def resource_group_name(ems_ref)
-    if (match = ems_ref.match(%r{/subscriptions/[^/]+/resourceGroups/(?<name>[^/]+)/.+}i))
+    if (match = ems_ref.match(%r{/subscriptions/[^/]+/resourceGroups/(?<name>[^/]+)(/.+)?}i))
       match[:name].downcase
     end
   end
@@ -10,6 +10,13 @@ module ManageIQ::Providers::AzureStack::EmsRefMixin
   def resource_group_id(ems_ref)
     if (match = ems_ref.match(%r{(?<id>/subscriptions/[^/]+/resourceGroups/[^/]+)/.+}i))
       match[:id].downcase
+    end
+  end
+
+  # returns name of the resource group and name of the resource in an array
+  def resource_group_and_resource_name(ems_ref)
+    if (match = ems_ref.match(%r{/subscriptions/[^/]+/resourceGroups/(?<group_name>[^/]+).+/(?<name>[^/]+)}i))
+      [match[:group_name], match[:name]].each(&:downcase)
     end
   end
 end

--- a/app/models/manageiq/providers/azure_stack/inventory.rb
+++ b/app/models/manageiq/providers/azure_stack/inventory.rb
@@ -16,4 +16,15 @@ class ManageIQ::Providers::AzureStack::Inventory < ManageIQ::Providers::Inventor
     manager_name = "#{target.class.name.demodulize}::#{ems.api_version}" if manager_name.nil?
     class_for(ems, target, 'Collector', manager_name)
   end
+
+  def self.parser_classes_for(_ems, target)
+    case target
+    when InventoryRefresh::TargetCollection
+      [Parser::CloudManager, Parser::NetworkManager]
+    when ManageIQ::Providers::AzureStack::NetworkManager
+      [Parser::NetworkManager]
+    else
+      [Parser::CloudManager]
+    end
+  end
 end

--- a/app/models/manageiq/providers/azure_stack/inventory/collector.rb
+++ b/app/models/manageiq/providers/azure_stack/inventory/collector.rb
@@ -1,5 +1,6 @@
 class ManageIQ::Providers::AzureStack::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
   require_nested :CloudManager
+  require_nested :TargetCollection
 
   include ManageIQ::Providers::AzureStack::EmsRefMixin
 

--- a/app/models/manageiq/providers/azure_stack/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/azure_stack/inventory/collector/target_collection.rb
@@ -1,0 +1,164 @@
+class ManageIQ::Providers::AzureStack::Inventory::Collector::TargetCollection < ManageIQ::Providers::AzureStack::Inventory::Collector
+  require_nested :V2018_03_01
+  require_nested :V2017_03_09
+
+  def initialize(manager, target)
+    super
+
+    parse_targets!
+    infer_related_ems_refs!
+
+    # Reset the target cache, so we can access new targets inside
+    target.manager_refs_by_association_reset
+  end
+
+  # ##################################
+  # Target collection for CloudManager
+  # ##################################
+  def resource_groups
+    return @resource_groups unless @resource_groups.nil?
+
+    refs = references(:resource_groups) || []
+    @resource_groups = refs.map { |ems_ref| resource_group(ems_ref) }.compact
+  end
+
+  def resource_group(ems_ref)
+    group_name = resource_group_name(ems_ref)
+    safe_call { azure_resources.resource_groups.get(group_name) }
+  end
+
+  def resources(group_ems_ref)
+    group_name = resource_group_name(group_ems_ref)
+    safe_call { azure_resources.resources.list_by_resource_group(group_name) } || []
+  end
+
+  def vms
+    return [] if (refs = references(:vms)).blank?
+
+    refs.map { |ems_ref| vm(ems_ref) }.compact
+  end
+
+  def vm(ems_ref)
+    group_name, vm_name = resource_group_and_resource_name(ems_ref)
+
+    safe_call do
+      azure_compute.virtual_machines.get(group_name, vm_name).tap do |vm|
+        vm.instance_view = azure_compute.virtual_machines.instance_view(group_name, vm_name)
+      end
+    end
+  end
+
+  def flavors
+    []
+  end
+
+  def orchestration_stacks
+    []
+  end
+
+  # ####################################
+  # Target collection for NetworkManager
+  # ####################################
+  def networks
+    return [] if (refs = references(:cloud_networks)).blank?
+
+    refs.map { |ems_ref| network(ems_ref) }.compact
+  end
+
+  def network(ems_ref)
+    group_name, network_name = resource_group_and_resource_name(ems_ref)
+    safe_call { azure_network.virtual_networks.get(group_name, network_name) }
+  end
+
+  def network_ports
+    return [] if (refs = references(:network_ports)).blank?
+
+    refs.map { |ems_ref| network_port(ems_ref) }.compact
+  end
+
+  def network_port(ems_ref)
+    group_name, port_name = resource_group_and_resource_name(ems_ref)
+    safe_call { azure_network.network_interfaces.get(group_name, port_name) }
+  end
+
+  def security_groups
+    return [] if (refs = references(:security_groups)).blank?
+
+    refs.map { |ems_ref| security_group(ems_ref) }.compact
+  end
+
+  def security_group(ems_ref)
+    group_name, security_group_name = resource_group_and_resource_name(ems_ref)
+    safe_call { azure_network.network_security_groups.get(group_name, security_group_name) }
+  end
+
+  private
+
+  def safe_call
+    yield
+  rescue MsRestAzure::AzureOperationError => err
+    $azure_stack_log.error("error: #{err}")
+    nil
+  end
+
+  def references(collection)
+    refs = target.manager_refs_by_association.try(:[], collection)
+    refs.try(:[], :ems_ref).try(:to_a) || []
+  end
+
+  def parse_targets!
+    target.targets.each do |target|
+      case target
+      when ResourceGroup
+        add_simple_target!(:resource_group, target.ems_ref)
+      end
+    end
+  end
+
+  def infer_related_ems_refs!
+    if references(:resource_groups).present?
+      infer_related_resource_groups_refs_db!
+      infer_related_resource_groups_refs_api!
+    end
+  end
+
+  def infer_related_resource_groups_refs_db!
+    changed_resource_groups = manager.resource_groups
+                                     .where(:ems_ref => references(:resource_groups))
+    changed_resource_groups.each do |resource_group|
+      resource_group.vms.each             { |vm| add_simple_target!(:vms, vm.ems_ref) }
+      resource_group.cloud_networks.each  { |network| add_simple_target!(:cloud_networks, network.ems_ref) }
+      resource_group.network_ports.each   { |port| add_simple_target!(:network_ports, port.ems_ref) }
+      resource_group.security_groups.each { |sg| add_simple_target!(:security_groups, sg.ems_ref) }
+    end
+  end
+
+  def infer_related_resource_groups_refs_api!
+    resource_groups.each do |resource_group|
+      group_ref = resource_group.id.downcase
+
+      resources(group_ref).each do |resource|
+        add_simple_target!(type_to_association(resource.type), resource.id.downcase)
+      end
+    end
+  end
+
+  def type_to_association(type)
+    case type.downcase
+    when "microsoft.compute/virtualmachines"
+      :vms
+    when "microsoft.network/networkinterfaces"
+      :network_ports
+    when "microsoft.network/networksecuritygroups"
+      :security_groups
+    when "microsoft.network/virtualnetworks"
+      :cloud_networks
+    end
+  end
+
+  def add_simple_target!(association, ems_ref)
+    return if association.nil? || ems_ref.blank?
+
+    target.add_target(:association => association, :manager_ref => {:ems_ref => ems_ref})
+  end
+end

--- a/app/models/manageiq/providers/azure_stack/inventory/collector/target_collection/v2017_03_09.rb
+++ b/app/models/manageiq/providers/azure_stack/inventory/collector/target_collection/v2017_03_09.rb
@@ -1,0 +1,18 @@
+# rubocop:disable Naming/ClassAndModuleCamelCase
+class ManageIQ::Providers::AzureStack::Inventory::Collector::TargetCollection::V2017_03_09 < ManageIQ::Providers::AzureStack::Inventory::Collector::TargetCollection
+  # ##################################
+  # Target collection for CloudManager
+  # ##################################
+  def resources(group_ems_ref)
+    group_name = resource_group_name(group_ems_ref)
+    safe_call { azure_resources.resource_groups.list_resources(group_name) }
+  end
+
+  def vm(ems_ref)
+    group_name, vm_name = resource_group_and_resource_name(ems_ref)
+    safe_call do
+      azure_compute.virtual_machines.get(group_name, vm_name, :expand => 'instanceView')
+    end
+  end
+end
+# rubocop:enable Naming/ClassAndModuleCamelCase

--- a/app/models/manageiq/providers/azure_stack/inventory/collector/target_collection/v2018_03_01.rb
+++ b/app/models/manageiq/providers/azure_stack/inventory/collector/target_collection/v2018_03_01.rb
@@ -1,0 +1,4 @@
+# rubocop:disable Naming/ClassAndModuleCamelCase
+class ManageIQ::Providers::AzureStack::Inventory::Collector::TargetCollection::V2018_03_01 < ManageIQ::Providers::AzureStack::Inventory::Collector::TargetCollection
+end
+# rubocop:enable Naming/ClassAndModuleCamelCase

--- a/app/models/manageiq/providers/azure_stack/inventory/persister.rb
+++ b/app/models/manageiq/providers/azure_stack/inventory/persister.rb
@@ -1,4 +1,5 @@
 class ManageIQ::Providers::AzureStack::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
   require_nested :CloudManager
   require_nested :NetworkManager
+  require_nested :TargetCollection
 end

--- a/app/models/manageiq/providers/azure_stack/inventory/persister/definitions/cloud_collections.rb
+++ b/app/models/manageiq/providers/azure_stack/inventory/persister/definitions/cloud_collections.rb
@@ -7,6 +7,7 @@ module ManageIQ::Providers::AzureStack::Inventory::Persister::Definitions::Cloud
       hardwares
       operating_systems
       flavors
+      miq_templates
       vms
       orchestration_stacks
     ].each do |name|

--- a/app/models/manageiq/providers/azure_stack/inventory/persister/definitions/network_collections.rb
+++ b/app/models/manageiq/providers/azure_stack/inventory/persister/definitions/network_collections.rb
@@ -2,14 +2,17 @@ module ManageIQ::Providers::AzureStack::Inventory::Persister::Definitions::Netwo
   extend ActiveSupport::Concern
 
   def initialize_network_inventory_collections
+    add_network_collections
+    add_related_cloud_collections
+  end
+
+  def add_network_collections
     %i[cloud_networks
        cloud_subnets
        network_ports
        security_groups].each do |name|
       add_collection(network, name)
     end
-
-    add_related_cloud_collections
   end
 
   def add_related_cloud_collections

--- a/app/models/manageiq/providers/azure_stack/inventory/persister/target_collection.rb
+++ b/app/models/manageiq/providers/azure_stack/inventory/persister/target_collection.rb
@@ -1,0 +1,17 @@
+class ManageIQ::Providers::AzureStack::Inventory::Persister::TargetCollection < ManageIQ::Providers::AzureStack::Inventory::Persister
+  include ManageIQ::Providers::AzureStack::Inventory::Persister::Definitions::CloudCollections
+  include ManageIQ::Providers::AzureStack::Inventory::Persister::Definitions::NetworkCollections
+
+  def initialize_inventory_collections
+    initialize_cloud_inventory_collections
+    add_network_collections
+  end
+
+  def targeted?
+    true
+  end
+
+  def strategy
+    :local_db_find_missing_references
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -42,8 +42,10 @@
 :ems_refresh:
   :azure_stack:
     :inventory_object_refresh: true
+    :allow_targeted_refresh: true
   :azure_stack_network:
     :inventory_object_refresh: true
+    :allow_targeted_refresh: true
 
 :workers:
   :worker_base:

--- a/spec/factories/cloud_network.rb
+++ b/spec/factories/cloud_network.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :cloud_network_azure_stack,
+          :parent => :cloud_network,
+          :class  => 'ManageIQ::Providers::AzureStack::NetworkManager::CloudNetwork'
+end

--- a/spec/factories/network_port.rb
+++ b/spec/factories/network_port.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :network_port_azure_stack,
+          :parent => :network_port,
+          :class  => 'ManageIQ::Providers::AzureStack::NetworkManager::NetworkPort'
+end

--- a/spec/factories/resource_group.rb
+++ b/spec/factories/resource_group.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :resource_group_azure_stack,
+          :parent => :resource_group,
+          :class  => 'ManageIQ::Providers::AzureStack::ResourceGroup'
+end

--- a/spec/factories/security_group.rb
+++ b/spec/factories/security_group.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :security_group_azure_stack,
+          :parent => :security_group,
+          :class  => 'ManageIQ::Providers::AzureStack::NetworkManager::SecurityGroup'
+end

--- a/spec/models/manageiq/providers/azure_stack/cloud_manager/vcr_specs/targeted_refresh_spec.rb
+++ b/spec/models/manageiq/providers/azure_stack/cloud_manager/vcr_specs/targeted_refresh_spec.rb
@@ -1,0 +1,204 @@
+describe ManageIQ::Providers::AzureStack::CloudManager::Refresher do
+  let(:subscription) { Rails.application.secrets.azure_stack.try(:[], :subscription) || 'AZURE_STACK_SUBSCRIPTION' }
+
+  REFRESH_SETTINGS = [
+    {
+      :inventory_object_refresh => true,
+      :allow_targeted_refresh   => true,
+      :inventory_collections    => {
+        :saver_strategy => :default
+      }
+    }
+  ].freeze
+
+  supported_api_versions do |api_version|
+    let!(:ems) do
+      ems = FactoryBot.create(:ems_azure_stack_with_vcr_authentication, :skip_validate, :api_version => api_version)
+      allow(ems).to receive(:hostname_format_valid?).and_return(true) # or else "AZURE_STACK_HOST" gets rejected
+      ems
+    end
+
+    describe "targeted refresh" do
+      # names of test resources in the VCR cassettes
+      let(:resource_group_name) { 'demo-resource-group' }
+      let(:vm_name)             { 'demoVm' }
+      let(:network_name)        { 'demoNetwork' }
+      let(:port_name)           { 'demoNic0' }
+      let(:security_group_name) { 'demoSecurityGroup' }
+
+      REFRESH_SETTINGS.each do |refresh_settings|
+        context "with settings #{refresh_settings}" do
+          before(:each) do
+            stub_settings_merge(
+              :ems_refresh => {
+                :azure_stack         => refresh_settings,
+                :azure_stack_network => refresh_settings
+              }
+            )
+          end
+
+          let(:resource_group_ref) { "/subscriptions/#{subscription}/resourcegroups/#{resource_group_name}".downcase }
+          # ensure that the flavor associated with the VM in our
+          # test deployment is present in the DB
+          let!(:flavor) do
+            FactoryBot.create(:flavor,
+                              :ems_id  => ems.id,
+                              :ems_ref => 'standard_a1',
+                              :memory  => 1.gigabyte)
+          end
+
+          describe "on empty database" do
+            let(:resource_group) do
+              FactoryBot.build(:resource_group_azure_stack,
+                               :ems_id  => ems.id,
+                               :ems_ref => resource_group_ref)
+            end
+
+            it "creates a resource group" do
+              test_targeted_refresh([resource_group], 'resource_group') do
+                assert_resource_counts
+                assert_specific_resource_group
+              end
+            end
+          end
+
+          describe "on populated database" do
+            context "objects are updated on remote server" do
+              let(:vm_ref)             { "/subscriptions/#{subscription}/resourcegroups/#{resource_group_name}/providers/microsoft.compute/virtualmachines/#{vm_name}".downcase }
+              let(:network_ref)        { "/subscriptions/#{subscription}/resourcegroups/#{resource_group_name}/providers/microsoft.network/virtualnetworks/#{network_name}".downcase }
+              let(:network_port_ref)   { "/subscriptions/#{subscription}/resourcegroups/#{resource_group_name}/providers/microsoft.network/networkinterfaces/#{port_name}".downcase }
+              let(:security_group_ref) { "/subscriptions/#{subscription}/resourcegroups/#{resource_group_name}/providers/microsoft.network/networksecuritygroups/#{security_group_name}".downcase }
+
+              let!(:resource_group) do
+                FactoryBot.create(:resource_group_azure_stack,
+                                  :ems_id  => ems.id,
+                                  :ems_ref => resource_group_ref,
+                                  :name    => "dummy")
+              end
+              let!(:vm) do
+                FactoryBot.create(:vm_azure_stack,
+                                  :ems_id          => ems.id,
+                                  :ems_ref         => vm_ref,
+                                  :name            => "dummy",
+                                  :raw_power_state => "dummy",
+                                  :resource_group  => resource_group)
+              end
+              let!(:network) do
+                FactoryBot.create(:cloud_network,
+                                  :ems_id         => ems.network_manager.id,
+                                  :ems_ref        => network_ref,
+                                  :name           => "dummy",
+                                  :resource_group => resource_group)
+              end
+              let!(:port) do
+                FactoryBot.create(:network_port_azure_stack,
+                                  :ems_id         => ems.network_manager.id,
+                                  :ems_ref        => network_port_ref,
+                                  :name           => "dummy",
+                                  :mac_address    => "dummy",
+                                  :resource_group => resource_group)
+              end
+              let!(:security_group) do
+                FactoryBot.create(:security_group,
+                                  :ems_id         => ems.network_manager.id,
+                                  :ems_ref        => security_group_ref,
+                                  :name           => "dummy",
+                                  :resource_group => resource_group)
+              end
+
+              it "resource group is updated" do
+                test_targeted_refresh([resource_group], 'resource_group') do
+                  assert_updated(resource_group, :name => resource_group_name)
+                  assert_updated(vm, :name            => vm_name,
+                                     :raw_power_state => "PowerState/running",
+                                     :flavor          => flavor)
+                  assert_updated(network, :name => network_name)
+                  assert_updated(port, :name => port_name, :mac_address => "001DD8B700FC")
+                  assert_updated(security_group, :name => security_group_name)
+                end
+              end
+            end
+
+            context "objects are deleted from the remote server" do
+              let(:resource_group) do
+                FactoryBot.create(:resource_group_azure_stack,
+                                  :ems_id  => ems.id,
+                                  :ems_ref => "/subscriptions/#{subscription}/resourcegroups/nonexistent")
+              end
+
+              it "resource group is deleted" do
+                test_targeted_refresh([resource_group], "resource_group_deleted", :repeat => 1) do
+                  assert_deleted(resource_group)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  def test_targeted_refresh(targets, cassette, repeat: 2)
+    targets = inventory_refresh_targets(targets)
+    repeat.times do # Run twice to verify that a second run with existing data does not change anything
+      EmsRefresh.queue_refresh(targets)
+      expect(MiqQueue.where(:method_name => 'refresh').count).to eq 1
+      refresh_job = MiqQueue.where(:method_name => 'refresh').first
+
+      vcr_with_auth("#{described_class.name.underscore}_targeted/#{api_version}-#{cassette}") do
+        status, msg, _ = refresh_job.deliver
+        expect(:status => status, :msg => msg).not_to include(:status => 'error')
+      end
+
+      ems.reload
+      yield
+    end
+  end
+
+  def inventory_refresh_targets(targets)
+    targets.map do |target|
+      case target
+      when InventoryRefresh::Target
+        return target
+      when ResourceGroup
+        association = :resource_groups
+      end
+
+      InventoryRefresh::Target.new(
+        :manager     => ems,
+        :association => association,
+        :manager_ref => { :ems_ref => target.ems_ref }
+      )
+    end
+  end
+
+  def assert_resource_counts
+    expect(ResourceGroup.count).to eq(1)
+    expect(Vm.count).to eq(1)
+    expect(CloudNetwork.count).to eq(1)
+    expect(CloudSubnet.count).to eq(1)
+    expect(NetworkPort.count).to eq(1)
+    expect(SecurityGroup.count).to eq(1)
+  end
+
+  def assert_specific_resource_group
+    resource_group = ResourceGroup.find_by(:name => resource_group_name)
+    expect(resource_group).not_to be_nil
+    expect(ems_ref_suffix(resource_group.ems_ref)).to eq('')
+    expect(resource_group.name).to eq(resource_group_name)
+
+    expect(resource_group.vms.size).to eq(1)
+    expect(resource_group.cloud_networks.size).to eq(1)
+    expect(resource_group.network_ports.size).to eq(1)
+    expect(resource_group.security_groups.size).to eq(1)
+  end
+
+  def assert_updated(obj, attrs)
+    obj.reload
+    expect(obj).to have_attributes(attrs)
+  end
+
+  def assert_deleted(obj)
+    expect { obj.reload }.to raise_error(ActiveRecord::RecordNotFound)
+  end
+end

--- a/spec/vcr_cassettes/manageiq/providers/azure_stack/cloud_manager/refresher_targeted/V2017_03_09-resource_group.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure_stack/cloud_manager/refresher_targeted/V2017_03_09-resource_group.yml
@@ -1,0 +1,504 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://AZURE_STACK_HOST/subscriptions/AZURE_STACK_SUBSCRIPTION/resourcegroups/demo-resource-group?api-version=2016-02-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.5.6 (x86_64-linux) ms_rest/0.7.4 ms_rest_azure/0.11.0 Azure-SDK-For-Ruby
+        azure_mgmt_resources/0.17.2 Profiles/V2017_03_09/Resources/Mgmt
+      Content-Type:
+      - application/json; charset=utf-8
+      Accept:
+      - application/json
+      Accept-Language:
+      - en-US
+      X-Ms-Client-Request-Id:
+      - b03924ee-fa4e-4450-b9a5-77c1c6f1a840
+      Authorization:
+      - Bearer AZURE_STACK_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - abde81ac-50bd-4963-9586-5a6b40acf229
+      X-Ms-Correlation-Request-Id:
+      - abde81ac-50bd-4963-9586-5a6b40acf229
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20191007T054031Z:abde81ac-50bd-4963-9586-5a6b40acf229
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 07 Oct 2019 05:40:31 GMT
+      Content-Length:
+      - '191'
+    body:
+      encoding: UTF-8
+      string: '{"id":"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group","name":"demo-resource-group","location":"westus","properties":{"provisioningState":"Succeeded"}}'
+    http_version: 
+  recorded_at: Mon, 07 Oct 2019 05:40:31 GMT
+- request:
+    method: get
+    uri: https://AZURE_STACK_HOST/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/resources?api-version=2016-02-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.5.6 (x86_64-linux) ms_rest/0.7.4 ms_rest_azure/0.11.0 Azure-SDK-For-Ruby
+        azure_mgmt_resources/0.17.2 Profiles/V2017_03_09/Resources/Mgmt
+      Content-Type:
+      - application/json; charset=utf-8
+      Accept:
+      - application/json
+      Accept-Language:
+      - en-US
+      X-Ms-Client-Request-Id:
+      - 8e3b54b9-7976-4da2-a6d3-abac7c4b440f
+      Authorization:
+      - Bearer AZURE_STACK_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - 4458929e-2b41-4924-8511-1210ff9ee449
+      X-Ms-Correlation-Request-Id:
+      - 4458929e-2b41-4924-8511-1210ff9ee449
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20191007T054031Z:4458929e-2b41-4924-8511-1210ff9ee449
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 07 Oct 2019 05:40:31 GMT
+      Content-Length:
+      - '1219'
+    body:
+      encoding: UTF-8
+      string: '{"value":[{"id":"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Compute/virtualMachines/demoVm","name":"demoVm","type":"Microsoft.Compute/virtualMachines","location":"westus"},{"id":"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkInterfaces/demoNic0","name":"demoNic0","type":"Microsoft.Network/networkInterfaces","location":"westus"},{"id":"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkSecurityGroups/demoSecurityGroup","name":"demoSecurityGroup","type":"Microsoft.Network/networkSecurityGroups","location":"westus"},{"id":"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/virtualNetworks/demoNetwork","name":"demoNetwork","type":"Microsoft.Network/virtualNetworks","location":"westus"},{"id":"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Storage/storageaccounts/demostorageaccount","name":"demostorageaccount","type":"Microsoft.Storage/storageaccounts","location":"westus"}]}'
+    http_version: 
+  recorded_at: Mon, 07 Oct 2019 05:40:31 GMT
+- request:
+    method: get
+    uri: https://AZURE_STACK_HOST/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Compute/virtualMachines/demovm?$expand=instanceView&api-version=2016-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.5.6 (x86_64-linux) ms_rest/0.7.4 ms_rest_azure/0.11.0 Azure-SDK-For-Ruby
+        azure_mgmt_compute/0.18.3 Profiles/V2017_03_09/Compute/Mgmt
+      Content-Type:
+      - application/json; charset=utf-8
+      Accept:
+      - application/json
+      Accept-Language:
+      - en-US
+      X-Ms-Client-Request-Id:
+      - 42433a53-e029-423e-b8d5-ac31462aa823
+      Authorization:
+      - Bearer AZURE_STACK_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '3237'
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 00000000-0000-0000-0000-000000000000_0
+      X-Ms-Correlation-Request-Id:
+      - 8dccf9ff-532f-46b6-af65-af71ec0e9ac1
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Www-Authenticate:
+      - oYG3MIG0oAMKAQChCwYJKoZIgvcSAQICooGfBIGcYIGZBgkqhkiG9xIBAgICAG+BiTCBhqADAgEFoQMCAQ+iejB4oAMCARKicQRvXPCgS47jIOFrHStpkde+C3LeryfNRFqimjyIynDAmrb5lmOqLTVRQosjkD2xUHVbhB3uD6EmrOsJS2UjLcIUaM2aienmlnBFxRUJyN2m77p7E/zVfD5Ql6rF4kzY02AYC2dSXx21FojIcnqntf1Y
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - 8dccf9ff-532f-46b6-af65-af71ec0e9ac1
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20191007T054033Z:8dccf9ff-532f-46b6-af65-af71ec0e9ac1
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 07 Oct 2019 05:40:33 GMT
+    body:
+      encoding: UTF-8
+      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"a883712d-c83b-46bf-996a-e1fd9249db4b\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_A1\"\r\n    },\r\n
+        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
+        \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\":
+        {\r\n        \"osType\": \"Linux\",\r\n        \"name\": \"osdisk\",\r\n        \"createOption\":
+        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://demostorageaccount.blob.westus.stackpoc.com/vhds/osdisk.vhd\"\r\n
+        \       },\r\n        \"caching\": \"ReadWrite\",\r\n        \"diskSizeGB\":
+        30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
+        {\r\n      \"computerName\": \"demoVm\",\r\n      \"adminUsername\": \"demoUsername\",\r\n
+        \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
+        false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\":
+        {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkInterfaces/demoNic0\"}]},\r\n
+        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
+        true,\r\n        \"storageUri\": \"https://demostorageaccount.blob.westus.stackpoc.com/\"\r\n
+        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\":
+        {\r\n      \"rdpThumbPrint\": \"SHA256XHAe/JzGhoNXWT09f3959tnBCeWXJsEacg3ezfBD/M8\",\r\n
+        \     \"vmAgent\": {\r\n        \"vmAgentVersion\": \"2.2.38.0\",\r\n        \"statuses\":
+        [\r\n          {\r\n            \"code\": \"ProvisioningState/Succeeded\",\r\n
+        \           \"level\": \"Info\",\r\n            \"displayStatus\": \"Ready\",\r\n
+        \           \"message\": \"Guest Agent is running\",\r\n            \"time\":
+        \"2019-10-07T05:40:33+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\":
+        []\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"osdisk\",\r\n
+        \         \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/Succeeded\",\r\n
+        \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
+        Succeeded\",\r\n              \"time\": \"2019-10-06T18:24:30.678712+00:00\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"bootDiagnostics\":
+        {\r\n        \"consoleScreenshotBlobUri\": \"https://demostorageaccount.blob.westus.stackpoc.com/bootdiagnostics-demovm-a883712d-c83b-46bf-996a-e1fd9249db4b/demoVm.a883712d-c83b-46bf-996a-e1fd9249db4b.screenshot.bmp\",\r\n
+        \       \"serialConsoleLogBlobUri\": \"https://demostorageaccount.blob.westus.stackpoc.com/bootdiagnostics-demovm-a883712d-c83b-46bf-996a-e1fd9249db4b/demoVm.a883712d-c83b-46bf-996a-e1fd9249db4b.serialconsole.log\"\r\n
+        \     },\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/Succeeded/osProvisioningComplete\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"OS provisioning
+        complete\",\r\n          \"time\": \"2019-10-06T18:29:22.6892294+00:00\"\r\n
+        \       },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
+        \ \"location\": \"westus\",\r\n  \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Compute/virtualMachines/demoVm\",\r\n
+        \ \"name\": \"demoVm\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 07 Oct 2019 05:40:33 GMT
+- request:
+    method: get
+    uri: https://AZURE_STACK_HOST/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/virtualNetworks/demonetwork?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.5.6 (x86_64-linux) ms_rest/0.7.4 ms_rest_azure/0.11.0 Azure-SDK-For-Ruby
+        azure_mgmt_network/0.18.2 Profiles/V2017_03_09/Network/Mgmt
+      Content-Type:
+      - application/json; charset=utf-8
+      Accept:
+      - application/json
+      Accept-Language:
+      - en-US
+      X-Ms-Client-Request-Id:
+      - a59227c9-2f03-4fd9-b6fe-82004da0db47
+      Authorization:
+      - Bearer AZURE_STACK_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '1528'
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"a63b2c13-7037-447f-bdb3-f76125960d7c"
+      X-Ms-Correlation-Request-Id:
+      - 6b78c619-24af-4915-ae7b-a813b020dc3b
+      X-Ms-Request-Id:
+      - 02d9300e-8758-4317-8cbd-a586bda61fd1
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Www-Authenticate:
+      - oYG3MIG0oAMKAQChCwYJKoZIgvcSAQICooGfBIGcYIGZBgkqhkiG9xIBAgICAG+BiTCBhqADAgEFoQMCAQ+iejB4oAMCARKicQRvhDD7SWtLjujAxKvQl+dp+M6nLhjrYApSdLHKkwHsZePcEjYQtkI2ZkJnnX7qPhjaIK7tRqy0L8s3fWCQwbJoRXFV8p8PdKtyuYcl2y0zjlHQoxRKYlHMJOfvX7mCHRyrHfquUKTftS/LSZBj/WlF
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20191007T054033Z:6b78c619-24af-4915-ae7b-a813b020dc3b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 07 Oct 2019 05:40:33 GMT
+    body:
+      encoding: UTF-8
+      string: "{\r\n  \"name\": \"demoNetwork\",\r\n  \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/virtualNetworks/demoNetwork\",\r\n
+        \ \"etag\": \"W/\\\"a63b2c13-7037-447f-bdb3-f76125960d7c\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"22e09ae9-5328-49ea-94ed-8b6a0542619e\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
+        [\r\n        \"10.0.0.0/24\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
+        \     {\r\n        \"name\": \"demoSubnet\",\r\n        \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/virtualNetworks/demoNetwork/subnets/demoSubnet\",\r\n
+        \       \"etag\": \"W/\\\"a63b2c13-7037-447f-bdb3-f76125960d7c\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"addressPrefix\": \"10.0.0.0/24\",\r\n          \"networkSecurityGroup\":
+        {\r\n            \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkSecurityGroups/demoSecurityGroup\"\r\n
+        \         },\r\n          \"ipConfigurations\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkInterfaces/demoNic0/ipConfigurations/ipconfig1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 07 Oct 2019 05:40:33 GMT
+- request:
+    method: get
+    uri: https://AZURE_STACK_HOST/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkInterfaces/demonic0?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.5.6 (x86_64-linux) ms_rest/0.7.4 ms_rest_azure/0.11.0 Azure-SDK-For-Ruby
+        azure_mgmt_network/0.18.2 Profiles/V2017_03_09/Network/Mgmt
+      Content-Type:
+      - application/json; charset=utf-8
+      Accept:
+      - application/json
+      Accept-Language:
+      - en-US
+      X-Ms-Client-Request-Id:
+      - a7d6047c-5ba0-4353-b470-bd28eab7fb1e
+      Authorization:
+      - Bearer AZURE_STACK_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '1836'
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"745dab4c-00af-4705-8a96-8db9d33bc734"
+      X-Ms-Correlation-Request-Id:
+      - 88671c12-cff4-4f3a-9e98-be5fbe8fa52d
+      X-Ms-Request-Id:
+      - 3975d478-2a19-4dfd-b53d-0070f2a6727a
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Www-Authenticate:
+      - oYG3MIG0oAMKAQChCwYJKoZIgvcSAQICooGfBIGcYIGZBgkqhkiG9xIBAgICAG+BiTCBhqADAgEFoQMCAQ+iejB4oAMCARKicQRvXiyUBJe9xPsaCWRMr00Qk5GwMQ9SHKRfI9xvmVUQG2cdlS50DpqLOSFXAqe4Oxx3TUFrcsCSWXlYCVimPGqDSY07w9/OrMWagdiyZxTqXuJXvsK6qryV3rkTnxKGhqiSNzltih44XSaw2rkauiog
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20191007T054034Z:88671c12-cff4-4f3a-9e98-be5fbe8fa52d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 07 Oct 2019 05:40:34 GMT
+    body:
+      encoding: UTF-8
+      string: "{\r\n  \"name\": \"demoNic0\",\r\n  \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkInterfaces/demoNic0\",\r\n
+        \ \"etag\": \"W/\\\"745dab4c-00af-4705-8a96-8db9d33bc734\\\"\",\r\n  \"location\":
+        \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"c36fb7fd-8853-4c07-aff0-6161a481206c\",\r\n    \"ipConfigurations\":
+        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkInterfaces/demoNic0/ipConfigurations/ipconfig1\",\r\n
+        \       \"etag\": \"W/\\\"745dab4c-00af-4705-8a96-8db9d33bc734\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/networkInterfaces/ipConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/virtualNetworks/demoNetwork/subnets/demoSubnet\"\r\n
+        \         },\r\n          \"primary\": true\r\n        }\r\n      }\r\n    ],\r\n
+        \   \"dnsSettings\": {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\":
+        []\r\n    },\r\n    \"macAddress\": \"001DD8B700FC\",\r\n    \"enableIPForwarding\":
+        false,\r\n    \"networkSecurityGroup\": {\r\n      \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkSecurityGroups/demoSecurityGroup\"\r\n
+        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
+        \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Compute/virtualMachines/demoVm\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 07 Oct 2019 05:40:34 GMT
+- request:
+    method: get
+    uri: https://AZURE_STACK_HOST/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkSecurityGroups/demosecuritygroup?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.5.6 (x86_64-linux) ms_rest/0.7.4 ms_rest_azure/0.11.0 Azure-SDK-For-Ruby
+        azure_mgmt_network/0.18.2 Profiles/V2017_03_09/Network/Mgmt
+      Content-Type:
+      - application/json; charset=utf-8
+      Accept:
+      - application/json
+      Accept-Language:
+      - en-US
+      X-Ms-Client-Request-Id:
+      - '09bfa5ae-bec9-425f-84c0-b264cdf2b4db'
+      Authorization:
+      - Bearer AZURE_STACK_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '6897'
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"8be1c1cc-2986-4641-aae5-e5ba7a9c6ed4"
+      X-Ms-Correlation-Request-Id:
+      - 186e5147-3417-48d4-b2a7-912f4ad331c3
+      X-Ms-Request-Id:
+      - '09e825bc-b499-477f-9ab2-8723ad4c4881'
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Www-Authenticate:
+      - oYG3MIG0oAMKAQChCwYJKoZIgvcSAQICooGfBIGcYIGZBgkqhkiG9xIBAgICAG+BiTCBhqADAgEFoQMCAQ+iejB4oAMCARKicQRvWqEDq3PQdtfuKft2WNaL76ivTDMhPCE071X+PWqdB1n4JGH0/dXEK/hzMbDLqXC3dHQFBIpkGq6z77xHJi4lbFchXaNiUewfxeEuYeNO3XwUIUJo2vdHOH98iPp6RAXqT3JSLYHpw3p26juosiHS
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20191007T054035Z:186e5147-3417-48d4-b2a7-912f4ad331c3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 07 Oct 2019 05:40:34 GMT
+    body:
+      encoding: UTF-8
+      string: "{\r\n  \"name\": \"demoSecurityGroup\",\r\n  \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkSecurityGroups/demoSecurityGroup\",\r\n
+        \ \"etag\": \"W/\\\"8be1c1cc-2986-4641-aae5-e5ba7a9c6ed4\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\": \"westus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"89cce752-0d4e-486a-b7b5-dfe699a6e084\",\r\n    \"securityRules\": [\r\n
+        \     {\r\n        \"name\": \"ssh\",\r\n        \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkSecurityGroups/demoSecurityGroup/securityRules/ssh\",\r\n
+        \       \"etag\": \"W/\\\"8be1c1cc-2986-4641-aae5-e5ba7a9c6ed4\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/networkSecurityGroups/securityRules\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow RDP\",\r\n          \"protocol\": \"Tcp\",\r\n
+        \         \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"22\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Allow\",\r\n          \"priority\": 200,\r\n
+        \         \"direction\": \"Inbound\"\r\n        }\r\n      }\r\n    ],\r\n
+        \   \"defaultSecurityRules\": [\r\n      {\r\n        \"name\": \"AllowVnetInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkSecurityGroups/demoSecurityGroup/defaultSecurityRules/AllowVnetInBound\",\r\n
+        \       \"etag\": \"W/\\\"8be1c1cc-2986-4641-aae5-e5ba7a9c6ed4\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Inbound\"\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkSecurityGroups/demoSecurityGroup/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
+        \       \"etag\": \"W/\\\"8be1c1cc-2986-4641-aae5-e5ba7a9c6ed4\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"AzureLoadBalancer\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\":
+        \"Inbound\"\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkSecurityGroups/demoSecurityGroup/defaultSecurityRules/DenyAllInBound\",\r\n
+        \       \"etag\": \"W/\\\"8be1c1cc-2986-4641-aae5-e5ba7a9c6ed4\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all inbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Inbound\"\r\n        }\r\n      },\r\n      {\r\n
+        \       \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkSecurityGroups/demoSecurityGroup/defaultSecurityRules/AllowVnetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"8be1c1cc-2986-4641-aae5-e5ba7a9c6ed4\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to all VMs
+        in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\":
+        \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Outbound\"\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowInternetOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkSecurityGroups/demoSecurityGroup/defaultSecurityRules/AllowInternetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"8be1c1cc-2986-4641-aae5-e5ba7a9c6ed4\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"Internet\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\": \"Outbound\"\r\n
+        \       }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkSecurityGroups/demoSecurityGroup/defaultSecurityRules/DenyAllOutBound\",\r\n
+        \       \"etag\": \"W/\\\"8be1c1cc-2986-4641-aae5-e5ba7a9c6ed4\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all outbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Outbound\"\r\n        }\r\n      }\r\n    ],\r\n
+        \   \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkInterfaces/demoNic0\"\r\n
+        \     }\r\n    ],\r\n    \"subnets\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/virtualNetworks/demoNetwork/subnets/demoSubnet\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 07 Oct 2019 05:40:35 GMT
+recorded_with: VCR 5.0.0

--- a/spec/vcr_cassettes/manageiq/providers/azure_stack/cloud_manager/refresher_targeted/V2017_03_09-resource_group_deleted.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure_stack/cloud_manager/refresher_targeted/V2017_03_09-resource_group_deleted.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://AZURE_STACK_HOST/subscriptions/AZURE_STACK_SUBSCRIPTION/resourcegroups/nonexistent?api-version=2016-02-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+        - Ruby/2.5.6 (x86_64-linux) ms_rest/0.7.4 ms_rest_azure/0.11.0 Azure-SDK-For-Ruby
+          azure_mgmt_resources/0.17.2 Profiles/V2017_03_09/Resources/Mgmt
+      Content-Type:
+        - application/json; charset=utf-8
+      Accept:
+        - application/json
+      Accept-Language:
+        - en-US
+      X-Ms-Client-Request-Id:
+        - 82b25de1-f5ad-4d6b-903b-5a6abbfd2a7b
+      Authorization:
+        - Bearer AZURE_STACK_TOKEN
+      Accept-Encoding:
+        - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+        - no-cache
+      Pragma:
+        - no-cache
+      Content-Type:
+        - application/json; charset=utf-8
+      Expires:
+        - "-1"
+      X-Ms-Failure-Cause:
+        - gateway
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+        - '14990'
+      X-Ms-Request-Id:
+        - a412f996-a5ff-4f6d-a99a-604ef67d5c16
+      X-Ms-Correlation-Request-Id:
+        - a412f996-a5ff-4f6d-a99a-604ef67d5c16
+      X-Ms-Routing-Request-Id:
+        - WESTUS:20191003T064012Z:a412f996-a5ff-4f6d-a99a-604ef67d5c16
+      Strict-Transport-Security:
+        - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+        - nosniff
+      Date:
+        - Thu, 03 Oct 2019 06:40:12 GMT
+      Content-Length:
+        - '103'
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"ResourceGroupNotFound","message":"Resource group
+        ''nonexistent'' could not be found."}}'
+    http_version:
+  recorded_at: Thu, 03 Oct 2019 06:40:12 GMT
+recorded_with: VCR 5.0.0

--- a/spec/vcr_cassettes/manageiq/providers/azure_stack/cloud_manager/refresher_targeted/V2018_03_01-resource_group.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure_stack/cloud_manager/refresher_targeted/V2018_03_01-resource_group.yml
@@ -1,0 +1,582 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://AZURE_STACK_HOST/subscriptions/AZURE_STACK_SUBSCRIPTION/resourcegroups/demo-resource-group?api-version=2018-02-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.5.6 (x86_64-linux) ms_rest/0.7.4 ms_rest_azure/0.11.0 Azure-SDK-For-Ruby
+        azure_mgmt_resources/0.17.2 Profiles/V2018_03_01/Resources/Mgmt
+      Content-Type:
+      - application/json; charset=utf-8
+      Accept:
+      - application/json
+      Accept-Language:
+      - en-US
+      X-Ms-Client-Request-Id:
+      - 8c7b46c6-7bf4-4ded-b934-13a4c153d0b7
+      Authorization:
+      - Bearer AZURE_STACK_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Request-Id:
+      - b0f2fd7e-c63a-4a89-8c4b-864b3ec19ff6
+      X-Ms-Correlation-Request-Id:
+      - b0f2fd7e-c63a-4a89-8c4b-864b3ec19ff6
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20191007T054038Z:b0f2fd7e-c63a-4a89-8c4b-864b3ec19ff6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 07 Oct 2019 05:40:38 GMT
+      Content-Length:
+      - '191'
+    body:
+      encoding: UTF-8
+      string: '{"id":"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group","name":"demo-resource-group","location":"westus","properties":{"provisioningState":"Succeeded"}}'
+    http_version: 
+  recorded_at: Mon, 07 Oct 2019 05:40:38 GMT
+- request:
+    method: get
+    uri: https://AZURE_STACK_HOST/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/resources?api-version=2018-02-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.5.6 (x86_64-linux) ms_rest/0.7.4 ms_rest_azure/0.11.0 Azure-SDK-For-Ruby
+        azure_mgmt_resources/0.17.2 Profiles/V2018_03_01/Resources/Mgmt
+      Content-Type:
+      - application/json; charset=utf-8
+      Accept:
+      - application/json
+      Accept-Language:
+      - en-US
+      X-Ms-Client-Request-Id:
+      - 4b3c424a-76d6-45c3-8f04-4ad58d343ce1
+      Authorization:
+      - Bearer AZURE_STACK_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Request-Id:
+      - 5218568a-1e8f-4b2e-bab8-b29948632b36
+      X-Ms-Correlation-Request-Id:
+      - 5218568a-1e8f-4b2e-bab8-b29948632b36
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20191007T054038Z:5218568a-1e8f-4b2e-bab8-b29948632b36
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 07 Oct 2019 05:40:38 GMT
+      Content-Length:
+      - '1219'
+    body:
+      encoding: UTF-8
+      string: '{"value":[{"id":"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Compute/virtualMachines/demoVm","name":"demoVm","type":"Microsoft.Compute/virtualMachines","location":"westus"},{"id":"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkInterfaces/demoNic0","name":"demoNic0","type":"Microsoft.Network/networkInterfaces","location":"westus"},{"id":"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkSecurityGroups/demoSecurityGroup","name":"demoSecurityGroup","type":"Microsoft.Network/networkSecurityGroups","location":"westus"},{"id":"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/virtualNetworks/demoNetwork","name":"demoNetwork","type":"Microsoft.Network/virtualNetworks","location":"westus"},{"id":"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Storage/storageaccounts/demostorageaccount","name":"demostorageaccount","type":"Microsoft.Storage/storageaccounts","location":"westus"}]}'
+    http_version: 
+  recorded_at: Mon, 07 Oct 2019 05:40:38 GMT
+- request:
+    method: get
+    uri: https://AZURE_STACK_HOST/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Compute/virtualMachines/demovm?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.5.6 (x86_64-linux) ms_rest/0.7.4 ms_rest_azure/0.11.0 Azure-SDK-For-Ruby
+        azure_mgmt_compute/0.18.3 Profiles/V2018_03_01/Compute/Mgmt
+      Content-Type:
+      - application/json; charset=utf-8
+      Accept:
+      - application/json
+      Accept-Language:
+      - en-US
+      X-Ms-Client-Request-Id:
+      - '096630f5-9455-48f8-87e9-e0432c854726'
+      Authorization:
+      - Bearer AZURE_STACK_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '1537'
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 00000000-0000-0000-0000-000000000000_0
+      X-Ms-Correlation-Request-Id:
+      - 81144618-2d9b-41fe-ba41-f26479601dc2
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Www-Authenticate:
+      - oYG3MIG0oAMKAQChCwYJKoZIgvcSAQICooGfBIGcYIGZBgkqhkiG9xIBAgICAG+BiTCBhqADAgEFoQMCAQ+iejB4oAMCARKicQRvIyb1Pxs1C85sp2kHZ/xDA39dJxWHgVbc/ScoGx8UdASPw1VY2GSWH968o55dshuVuoDFxA3qKwtxe47aIDjQpY2cLaQH/DFrp6edx9sz13Z0gsAvmNSgPcbgAXEcKctlx1oLcVLz2boGNnDpLIk7
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Request-Id:
+      - 81144618-2d9b-41fe-ba41-f26479601dc2
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20191007T054039Z:81144618-2d9b-41fe-ba41-f26479601dc2
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 07 Oct 2019 05:40:39 GMT
+    body:
+      encoding: UTF-8
+      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"a883712d-c83b-46bf-996a-e1fd9249db4b\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_A1\"\r\n    },\r\n
+        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\":
+        \"16.04-LTS\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\":
+        {\r\n        \"osType\": \"Linux\",\r\n        \"name\": \"osdisk\",\r\n        \"createOption\":
+        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://demostorageaccount.blob.westus.stackpoc.com/vhds/osdisk.vhd\"\r\n
+        \       },\r\n        \"caching\": \"ReadWrite\",\r\n        \"diskSizeGB\":
+        30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
+        {\r\n      \"computerName\": \"demoVm\",\r\n      \"adminUsername\": \"demoUsername\",\r\n
+        \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
+        false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\":
+        {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkInterfaces/demoNic0\"}]},\r\n
+        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
+        true,\r\n        \"storageUri\": \"https://demostorageaccount.blob.westus.stackpoc.com/\"\r\n
+        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
+        \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus\",\r\n
+        \ \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Compute/virtualMachines/demoVm\",\r\n
+        \ \"name\": \"demoVm\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 07 Oct 2019 05:40:39 GMT
+- request:
+    method: get
+    uri: https://AZURE_STACK_HOST/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Compute/virtualMachines/demovm/instanceView?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.5.6 (x86_64-linux) ms_rest/0.7.4 ms_rest_azure/0.11.0 Azure-SDK-For-Ruby
+        azure_mgmt_compute/0.18.3 Profiles/V2018_03_01/Compute/Mgmt
+      Content-Type:
+      - application/json; charset=utf-8
+      Accept:
+      - application/json
+      Accept-Language:
+      - en-US
+      X-Ms-Client-Request-Id:
+      - 56d7334a-2cbd-4340-98cf-0f22f9d66385
+      Authorization:
+      - Bearer AZURE_STACK_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '1497'
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 00000000-0000-0000-0000-000000000000_0
+      X-Ms-Correlation-Request-Id:
+      - 17e2253c-618b-4605-a358-2b7dab299918
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Www-Authenticate:
+      - oYG3MIG0oAMKAQChCwYJKoZIgvcSAQICooGfBIGcYIGZBgkqhkiG9xIBAgICAG+BiTCBhqADAgEFoQMCAQ+iejB4oAMCARKicQRvDzRoKBOwtgRJ9D/5pdHAfuTTaH0sY4Xl4UfFvebZqZhIhiuS4ERKqAIGBoeEguwAqZHuIbYC6Z7MAhjMGItnBbUfAZjJbdH10anp4L8krPC6i73V0AQNwkSqK5OyLbJO8nJJahUxsopNTgKBArmk
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Request-Id:
+      - 17e2253c-618b-4605-a358-2b7dab299918
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20191007T054040Z:17e2253c-618b-4605-a358-2b7dab299918
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 07 Oct 2019 05:40:40 GMT
+    body:
+      encoding: UTF-8
+      string: "{\r\n  \"rdpThumbPrint\": \"SHA256XHAe/JzGhoNXWT09f3959tnBCeWXJsEacg3ezfBD/M8\",\r\n
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"2.2.38.0\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Succeeded\",\r\n        \"level\":
+        \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n        \"message\":
+        \"Guest Agent is running\",\r\n        \"time\": \"2019-10-07T05:40:40+00:00\"\r\n
+        \     }\r\n    ],\r\n    \"extensionHandlers\": []\r\n  },\r\n  \"disks\":
+        [\r\n    {\r\n      \"name\": \"osdisk\",\r\n      \"statuses\": [\r\n        {\r\n
+        \         \"code\": \"ProvisioningState/Succeeded\",\r\n          \"level\":
+        \"Info\",\r\n          \"displayStatus\": \"Provisioning Succeeded\",\r\n
+        \         \"time\": \"2019-10-06T18:24:30.678712+00:00\"\r\n        }\r\n
+        \     ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://demostorageaccount.blob.westus.stackpoc.com/bootdiagnostics-demovm-a883712d-c83b-46bf-996a-e1fd9249db4b/demoVm.a883712d-c83b-46bf-996a-e1fd9249db4b.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://demostorageaccount.blob.westus.stackpoc.com/bootdiagnostics-demovm-a883712d-c83b-46bf-996a-e1fd9249db4b/demoVm.a883712d-c83b-46bf-996a-e1fd9249db4b.serialconsole.log\"\r\n
+        \ },\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/Succeeded/osProvisioningComplete\",\r\n
+        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"OS provisioning complete\",\r\n
+        \     \"time\": \"2019-10-06T18:29:22.6892294+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/running\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM running\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 07 Oct 2019 05:40:40 GMT
+- request:
+    method: get
+    uri: https://AZURE_STACK_HOST/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/virtualNetworks/demonetwork?api-version=2017-10-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.5.6 (x86_64-linux) ms_rest/0.7.4 ms_rest_azure/0.11.0 Azure-SDK-For-Ruby
+        azure_mgmt_network/0.18.2 Profiles/V2018_03_01/Network/Mgmt
+      Content-Type:
+      - application/json; charset=utf-8
+      Accept:
+      - application/json
+      Accept-Language:
+      - en-US
+      X-Ms-Client-Request-Id:
+      - 818b59c2-daba-492c-b40b-cd3ed9b9bfac
+      Authorization:
+      - Bearer AZURE_STACK_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '1633'
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"a63b2c13-7037-447f-bdb3-f76125960d7c"
+      X-Ms-Correlation-Request-Id:
+      - 7d0e3af1-6563-47ac-a316-54a672670646
+      X-Ms-Request-Id:
+      - 87e40424-f763-4f24-a7ee-b5df41fc7ed4
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Www-Authenticate:
+      - oYG3MIG0oAMKAQChCwYJKoZIgvcSAQICooGfBIGcYIGZBgkqhkiG9xIBAgICAG+BiTCBhqADAgEFoQMCAQ+iejB4oAMCARKicQRvXcsu9DdJlkhTZRkWpNwkssEiEfZp3c3e8RnpMxadlFGUARU12T3iejnu5EKlltWPXgXSC2LEF4k1CalVwWDcDBzDxDMKu7YkxwSZjyKoulCcA/8Z9ptQe6XxxDgASNv9y3Ma1r9YeqgeWMLDemGQ
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20191007T054041Z:7d0e3af1-6563-47ac-a316-54a672670646
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 07 Oct 2019 05:40:40 GMT
+    body:
+      encoding: UTF-8
+      string: "{\r\n  \"name\": \"demoNetwork\",\r\n  \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/virtualNetworks/demoNetwork\",\r\n
+        \ \"etag\": \"W/\\\"a63b2c13-7037-447f-bdb3-f76125960d7c\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"22e09ae9-5328-49ea-94ed-8b6a0542619e\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
+        [\r\n        \"10.0.0.0/24\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
+        \     {\r\n        \"name\": \"demoSubnet\",\r\n        \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/virtualNetworks/demoNetwork/subnets/demoSubnet\",\r\n
+        \       \"etag\": \"W/\\\"a63b2c13-7037-447f-bdb3-f76125960d7c\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"addressPrefix\": \"10.0.0.0/24\",\r\n          \"networkSecurityGroup\":
+        {\r\n            \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkSecurityGroups/demoSecurityGroup\"\r\n
+        \         },\r\n          \"ipConfigurations\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkInterfaces/demoNic0/ipConfigurations/ipconfig1\"\r\n
+        \           }\r\n          ]\r\n        },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
+        \     }\r\n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
+        false,\r\n    \"enableVmProtection\": false\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 07 Oct 2019 05:40:41 GMT
+- request:
+    method: get
+    uri: https://AZURE_STACK_HOST/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkInterfaces/demonic0?api-version=2017-10-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.5.6 (x86_64-linux) ms_rest/0.7.4 ms_rest_azure/0.11.0 Azure-SDK-For-Ruby
+        azure_mgmt_network/0.18.2 Profiles/V2018_03_01/Network/Mgmt
+      Content-Type:
+      - application/json; charset=utf-8
+      Accept:
+      - application/json
+      Accept-Language:
+      - en-US
+      X-Ms-Client-Request-Id:
+      - 75429f3f-15b9-44e6-89a9-3eaeaacd08c6
+      Authorization:
+      - Bearer AZURE_STACK_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '2017'
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"745dab4c-00af-4705-8a96-8db9d33bc734"
+      X-Ms-Correlation-Request-Id:
+      - 99b509b6-3c99-4d18-8930-6ee2ec4d8ee5
+      X-Ms-Request-Id:
+      - 19a0f400-b22d-46d2-b0c9-dee5ed0a1afc
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Www-Authenticate:
+      - oYG3MIG0oAMKAQChCwYJKoZIgvcSAQICooGfBIGcYIGZBgkqhkiG9xIBAgICAG+BiTCBhqADAgEFoQMCAQ+iejB4oAMCARKicQRvMhV8BG01Kev6ejRKoWOPSKvHs5wf2eaolIiHZXawXp2o/V0PpuOR0Du4jkt6ciTNAYZPs4Nos/1fu5YBMHyE/iTdykxWOWu4aC2t/OVItozUjKeExw47ut0Ekl0ICd3vVMqPGDqQYxa3f86mmCGo
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14982'
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20191007T054042Z:99b509b6-3c99-4d18-8930-6ee2ec4d8ee5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 07 Oct 2019 05:40:42 GMT
+    body:
+      encoding: UTF-8
+      string: "{\r\n  \"name\": \"demoNic0\",\r\n  \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkInterfaces/demoNic0\",\r\n
+        \ \"etag\": \"W/\\\"745dab4c-00af-4705-8a96-8db9d33bc734\\\"\",\r\n  \"location\":
+        \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"c36fb7fd-8853-4c07-aff0-6161a481206c\",\r\n    \"ipConfigurations\":
+        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkInterfaces/demoNic0/ipConfigurations/ipconfig1\",\r\n
+        \       \"etag\": \"W/\\\"745dab4c-00af-4705-8a96-8db9d33bc734\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/networkInterfaces/ipConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/virtualNetworks/demoNetwork/subnets/demoSubnet\"\r\n
+        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
+        \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
+        [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
+        \"3gnoairikpvetfhnrnvakqtbtg.a--x.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
+        \"001DD8B700FC\",\r\n    \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\":
+        false,\r\n    \"networkSecurityGroup\": {\r\n      \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkSecurityGroups/demoSecurityGroup\"\r\n
+        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
+        \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Compute/virtualMachines/demoVm\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 07 Oct 2019 05:40:42 GMT
+- request:
+    method: get
+    uri: https://AZURE_STACK_HOST/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkSecurityGroups/demosecuritygroup?api-version=2017-10-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby/2.5.6 (x86_64-linux) ms_rest/0.7.4 ms_rest_azure/0.11.0 Azure-SDK-For-Ruby
+        azure_mgmt_network/0.18.2 Profiles/V2018_03_01/Network/Mgmt
+      Content-Type:
+      - application/json; charset=utf-8
+      Accept:
+      - application/json
+      Accept-Language:
+      - en-US
+      X-Ms-Client-Request-Id:
+      - fa05b2b7-9058-478b-a3ed-695ba1ac06c7
+      Authorization:
+      - Bearer AZURE_STACK_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '8017'
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"8be1c1cc-2986-4641-aae5-e5ba7a9c6ed4"
+      X-Ms-Correlation-Request-Id:
+      - ed9967ba-139b-4727-8fb1-2363cbfe9911
+      X-Ms-Request-Id:
+      - 52533a84-27b9-422a-9200-efce4a84f765
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Www-Authenticate:
+      - oYG3MIG0oAMKAQChCwYJKoZIgvcSAQICooGfBIGcYIGZBgkqhkiG9xIBAgICAG+BiTCBhqADAgEFoQMCAQ+iejB4oAMCARKicQRviz/zN8e9kadbDa5Tt+9DitRutHa+hDKlzHEiP0cAQ3gqopCF/n+LsBEBVJ++iRdpya/iexDogF5oSob8YCV7Nmf5T/oL6vOnTik13QgZXJNz64RA1jNqho86D+hZINRhB2MlUe1DDV8NzOUtDrjM
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14981'
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20191007T054043Z:ed9967ba-139b-4727-8fb1-2363cbfe9911
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 07 Oct 2019 05:40:42 GMT
+    body:
+      encoding: UTF-8
+      string: "{\r\n  \"name\": \"demoSecurityGroup\",\r\n  \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkSecurityGroups/demoSecurityGroup\",\r\n
+        \ \"etag\": \"W/\\\"8be1c1cc-2986-4641-aae5-e5ba7a9c6ed4\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\": \"westus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"89cce752-0d4e-486a-b7b5-dfe699a6e084\",\r\n    \"securityRules\": [\r\n
+        \     {\r\n        \"name\": \"ssh\",\r\n        \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkSecurityGroups/demoSecurityGroup/securityRules/ssh\",\r\n
+        \       \"etag\": \"W/\\\"8be1c1cc-2986-4641-aae5-e5ba7a9c6ed4\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/networkSecurityGroups/securityRules\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow RDP\",\r\n          \"protocol\": \"Tcp\",\r\n
+        \         \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"22\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Allow\",\r\n          \"priority\": 200,\r\n
+        \         \"direction\": \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n
+        \         \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      }\r\n
+        \   ],\r\n    \"defaultSecurityRules\": [\r\n      {\r\n        \"name\":
+        \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkSecurityGroups/demoSecurityGroup/defaultSecurityRules/AllowVnetInBound\",\r\n
+        \       \"etag\": \"W/\\\"8be1c1cc-2986-4641-aae5-e5ba7a9c6ed4\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkSecurityGroups/demoSecurityGroup/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
+        \       \"etag\": \"W/\\\"8be1c1cc-2986-4641-aae5-e5ba7a9c6ed4\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"AzureLoadBalancer\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkSecurityGroups/demoSecurityGroup/defaultSecurityRules/DenyAllInBound\",\r\n
+        \       \"etag\": \"W/\\\"8be1c1cc-2986-4641-aae5-e5ba7a9c6ed4\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all inbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n
+        \         \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      },\r\n
+        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkSecurityGroups/demoSecurityGroup/defaultSecurityRules/AllowVnetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"8be1c1cc-2986-4641-aae5-e5ba7a9c6ed4\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to all VMs
+        in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\":
+        \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Outbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowInternetOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkSecurityGroups/demoSecurityGroup/defaultSecurityRules/AllowInternetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"8be1c1cc-2986-4641-aae5-e5ba7a9c6ed4\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"Internet\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\": \"Outbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkSecurityGroups/demoSecurityGroup/defaultSecurityRules/DenyAllOutBound\",\r\n
+        \       \"etag\": \"W/\\\"8be1c1cc-2986-4641-aae5-e5ba7a9c6ed4\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/networkSecurityGroups/defaultSecurityRules\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all outbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Outbound\",\r\n          \"sourcePortRanges\":
+        [],\r\n          \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      }\r\n
+        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/networkInterfaces/demoNic0\"\r\n
+        \     }\r\n    ],\r\n    \"subnets\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_STACK_SUBSCRIPTION/resourceGroups/demo-resource-group/providers/Microsoft.Network/virtualNetworks/demoNetwork/subnets/demoSubnet\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 07 Oct 2019 05:40:43 GMT
+recorded_with: VCR 5.0.0

--- a/spec/vcr_cassettes/manageiq/providers/azure_stack/cloud_manager/refresher_targeted/V2018_03_01-resource_group_deleted.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure_stack/cloud_manager/refresher_targeted/V2018_03_01-resource_group_deleted.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+  - request:
+      method: get
+      uri: https://AZURE_STACK_HOST/subscriptions/AZURE_STACK_SUBSCRIPTION/resourcegroups/nonexistent?api-version=2018-02-01
+      body:
+        encoding: US-ASCII
+        string: ''
+      headers:
+        User-Agent:
+          - Ruby/2.5.6 (x86_64-linux) ms_rest/0.7.4 ms_rest_azure/0.11.0 Azure-SDK-For-Ruby
+            azure_mgmt_resources/0.17.2 Profiles/V2018_03_01/Resources/Mgmt
+        Content-Type:
+          - application/json; charset=utf-8
+        Accept:
+          - application/json
+        Accept-Language:
+          - en-US
+        X-Ms-Client-Request-Id:
+          - 98fd44db-4932-4ef6-a5fb-562c2b0875b9
+        Authorization:
+          - Bearer AZURE_STACK_TOKEN
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+    response:
+      status:
+        code: 404
+        message: Not Found
+      headers:
+        Cache-Control:
+          - no-cache
+        Pragma:
+          - no-cache
+        Content-Type:
+          - application/json; charset=utf-8
+        Expires:
+          - "-1"
+        X-Ms-Failure-Cause:
+          - gateway
+        X-Ms-Ratelimit-Remaining-Subscription-Reads:
+          - '14989'
+        X-Ms-Request-Id:
+          - 2a19679f-04c5-4303-9a93-6a4c1c9816f7
+        X-Ms-Correlation-Request-Id:
+          - 2a19679f-04c5-4303-9a93-6a4c1c9816f7
+        X-Ms-Routing-Request-Id:
+          - WESTUS:20191003T064014Z:2a19679f-04c5-4303-9a93-6a4c1c9816f7
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+        X-Content-Type-Options:
+          - nosniff
+        Date:
+          - Thu, 03 Oct 2019 06:40:14 GMT
+        Content-Length:
+          - '103'
+      body:
+        encoding: UTF-8
+        string: '{"error":{"code":"ResourceGroupNotFound","message":"Resource group
+        ''nonexistent'' could not be found."}}'
+      http_version:
+    recorded_at: Thu, 03 Oct 2019 06:40:14 GMT
+recorded_with: VCR 5.0.0


### PR DESCRIPTION
In this commit we implement targeted refresh for`ResourceGroup` targets.

When refresh is triggered for a `ResourceGroup`, we also refresh all the resources that are associated with resource groups, i. e. `Vm`s and (since #12) also `CloudNetwork`s, `NetworkPort`s and `SecurityGroup`s.

@miq-bot add_label enhancement
@miq-bot assign @agrare 
