### PR TITLE
Events to refresh resource group target

### DIFF
--- a/app/models/manageiq/providers/azure_stack/cloud_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/azure_stack/cloud_manager/event_target_parser.rb
@@ -1,0 +1,40 @@
+class ManageIQ::Providers::AzureStack::CloudManager::EventTargetParser
+  include ManageIQ::Providers::AzureStack::EmsRefMixin
+
+  attr_reader :ems_event
+
+  # @param ems_event [EmsEvent] EmsEvent object
+  def initialize(ems_event)
+    @ems_event = ems_event
+  end
+
+  # Parses all targets that are present in the EmsEvent given in the initializer
+  #
+  # @return [Array] Array of InventoryRefresh::Target objects
+  def parse
+    parse_ems_event_targets(ems_event)
+  end
+
+  # Parses list of InventoryRefresh::Target out of the given EmsEvent
+  #
+  # @param event [EmsEvent] EmsEvent object
+  # @return [Array] Array of InventoryRefresh::Target objects
+  def parse_ems_event_targets(event)
+    target_collection = InventoryRefresh::TargetCollection.new(:manager => event.ext_management_system, :event => event)
+
+    parse_event_target(target_collection, event.full_data)
+    targets = target_collection.targets
+
+    msg = "Mapped [#{event[:event_type]}] to refresh targets #{targets.map(&:manager_ref)}"
+    $azure_stack_log.debug(msg)
+
+    targets
+  end
+
+  def parse_event_target(target_collection, event_data)
+    id = event_data[:resource_id]
+    return unless id && (group_id = resource_group_id(id))
+
+    target_collection.add_target(:association => :resource_groups, :manager_ref => {:ems_ref => group_id})
+  end
+end

--- a/spec/models/manageiq/providers/azure_stack/cloud_manager/event_target_parser_spec.rb
+++ b/spec/models/manageiq/providers/azure_stack/cloud_manager/event_target_parser_spec.rb
@@ -1,0 +1,46 @@
+describe ManageIQ::Providers::AzureStack::CloudManager::EventTargetParser do
+  supported_api_versions do |api_version|
+    before do
+      _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+      @ems = FactoryBot.create(:ems_azure_stack_with_vcr_authentication, :skip_validate, :api_version => api_version, :zone => zone)
+    end
+
+    let(:resource_group)     { 'demo-resource-group' }
+    let(:resource_group_ref) { "/subscriptions/test/resourceGroups/#{resource_group}".downcase }
+
+    it "event triggers targeted refresh of resource group" do
+      event_data = event_double("/subscriptions/test/resourcegroups/#{resource_group}/dummyResources/dummy")
+      assert_event_triggers_targets(event_data, [[:resource_groups, {:ems_ref => resource_group_ref}]])
+    end
+
+    it "event from which we cannot infer resource group does nothing" do
+      event_data = event_double("dummy")
+      assert_event_triggers_targets(event_data, [])
+    end
+  end
+
+  def event_double(id)
+    double(
+      'event',
+      :resource_id     => id,
+      :event_timestamp => Time.now.utc
+    ).as_null_object
+  end
+
+  def assert_event_triggers_targets(event_data, expected_targets)
+    ems_event      = create_ems_event(event_data)
+    parsed_targets = described_class.new(ems_event).parse
+
+    expect(parsed_targets.size).to eq(expected_targets.count)
+    expect(target_references(parsed_targets)).to(match_array(expected_targets))
+  end
+
+  def target_references(parsed_targets)
+    parsed_targets.map { |x| [x.association, x.manager_ref] }.uniq
+  end
+
+  def create_ems_event(event_data)
+    event_hash = ManageIQ::Providers::AzureStack::CloudManager::EventParser.event_to_hash(event_data, @ems.id)
+    EmsEvent.add(@ems.id, event_hash)
+  end
+end


### PR DESCRIPTION
In this PR we implement `EventTargetParser` that creates a `ResourceGroup` target for any event coming from AzureStack. 

As long as we are able to identify the resource group of the resource associated with the event, we add the appropriate resource group as a target, as the provider is currently only able to refresh `ResourceGroup` targets.

@miq-bot add_label enhancement
@miq-bot assign @Ladas 

/cc @agrare @miha-plesko 