### PR TITLE
Rename event source from AZURE_STACK to AZURESTACK

### DIFF
--- a/app/models/manageiq/providers/azure_stack/cloud_manager/event_parser.rb
+++ b/app/models/manageiq/providers/azure_stack/cloud_manager/event_parser.rb
@@ -6,7 +6,7 @@ module ManageIQ::Providers::AzureStack::CloudManager::EventParser
 
     {
       :event_type => event_type(event),
-      :source     => 'AZURE_STACK',
+      :source     => 'AZURESTACK',
       :ems_ref    => full_data[:id].downcase,
       :timestamp  => full_data[:event_timestamp],
       :vm_ems_ref => full_data[:resource_type]&.downcase == INSTANCE_TYPE ? full_data[:resource_id]&.downcase : nil,

--- a/spec/models/manageiq/providers/azure_stack/cloud_manager/event_catcher/runner_spec.rb
+++ b/spec/models/manageiq/providers/azure_stack/cloud_manager/event_catcher/runner_spec.rb
@@ -27,7 +27,7 @@ describe ManageIQ::Providers::AzureStack::CloudManager::EventCatcher::Runner do
       expect(EmsEvent).to receive(:add_queue) do |method, ems_id, event_hash|
         expect(method).to eq('add')
         expect(ems_id).to eq(123)
-        expect(event_hash).to include(:source => 'AZURE_STACK', :ems_ref => '/event/456')
+        expect(event_hash).to include(:source => 'AZURESTACK', :ems_ref => '/event/456')
       end
       subject.queue_event(event)
     end

--- a/spec/models/manageiq/providers/azure_stack/cloud_manager/event_parser_spec.rb
+++ b/spec/models/manageiq/providers/azure_stack/cloud_manager/event_parser_spec.rb
@@ -37,7 +37,7 @@ describe ManageIQ::Providers::AzureStack::CloudManager::EventParser do
       it 'base_data' do
         expect(event_hash).to include(
           :event_type => 'Administrative_Microsoft.Compute_virtualMachines_restart_Started',
-          :source     => 'AZURE_STACK',
+          :source     => 'AZURESTACK',
           :ems_ref    => '/event/id',
           :timestamp  => '2019-01-07T20:00:00.000000Z',
           :vm_ems_ref => '/myresource/myid',
@@ -82,7 +82,7 @@ describe ManageIQ::Providers::AzureStack::CloudManager::EventParser do
       it 'base_data' do
         expect(event_hash).to include(
           :event_type => 'Administrative_Microsoft.Network_virtualNetworks_restart_Started',
-          :source     => 'AZURE_STACK',
+          :source     => 'AZURESTACK',
           :ems_ref    => '/event/id',
           :timestamp  => '2019-01-07T20:00:00.000000Z',
           :vm_ems_ref => nil,

--- a/spec/models/manageiq/providers/azure_stack/cloud_manager/vcr_specs/event_stream_spec.rb
+++ b/spec/models/manageiq/providers/azure_stack/cloud_manager/vcr_specs/event_stream_spec.rb
@@ -39,7 +39,7 @@ describe ManageIQ::Providers::AzureStack::CloudManager::EventCatcher::Stream do
   def assert_specific_event(event)
     expect(event).to include(
       :event_type => 'Administrative_Microsoft.Compute_virtualMachines_restart_Started',
-      :source     => 'AZURE_STACK',
+      :source     => 'AZURESTACK',
       :timestamp  => '2019-01-08T15:27:39.396015Z',
       :ems_id     => ems.id
     )


### PR DESCRIPTION
In this commit we modify the value of `:source` field in the hash returned by `EventParser.event_to_hash` to `'AZURESTACK'`.

Requested in [ManageIQ/manageiq-content/pull/588](https://github.com/ManageIQ/manageiq-content/pull/588), to keep the name of the automate class for AzureStack provider consistent with automate classes for other providers.

@miq-bot add_label refactoring
@miq-bot assign @agrare 