### PR TITLE
Remove metrics collector worker

### DIFF
--- a/app/models/manageiq/providers/azure_stack/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure_stack/cloud_manager.rb
@@ -2,7 +2,6 @@ class ManageIQ::Providers::AzureStack::CloudManager < ManageIQ::Providers::Cloud
   require_nested :EventCatcher
   require_nested :EventParser
   require_nested :MetricsCapture
-  require_nested :MetricsCollectorWorker
   require_nested :Refresher
   require_nested :RefreshWorker
   require_nested :Vm

--- a/app/models/manageiq/providers/azure_stack/cloud_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/azure_stack/cloud_manager/metrics_collector_worker.rb
@@ -1,9 +1,0 @@
-class ManageIQ::Providers::AzureStack::CloudManager::MetricsCollectorWorker < ManageIQ::Providers::BaseManager::MetricsCollectorWorker
-  require_nested :Runner
-
-  self.default_queue_name = "azure_stack"
-
-  def friendly_name
-    @friendly_name ||= "C&U Metrics Collector for AzureStack"
-  end
-end

--- a/app/models/manageiq/providers/azure_stack/cloud_manager/metrics_collector_worker/runner.rb
+++ b/app/models/manageiq/providers/azure_stack/cloud_manager/metrics_collector_worker/runner.rb
@@ -1,2 +1,0 @@
-class ManageIQ::Providers::AzureStack::CloudManager::MetricsCollectorWorker::Runner < ManageIQ::Providers::BaseManager::MetricsCollectorWorker::Runner
-end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -53,8 +53,6 @@
       :event_catcher_azure_stack:
         :poll: 20.seconds
     :queue_worker_base:
-      :ems_metrics_collector_worker:
-        :ems_metrics_collector_worker_azure_stack: {}
       :ems_refresh_worker:
         :ems_refresh_worker_azure_stack: {}
         :ems_refresh_worker_azure_stack_network: {}


### PR DESCRIPTION
This has been unused since azure stack's introduction in January
It can be re-added if needed.