### PR TITLE
Remove inventory refresh from settings

### DIFF
--- a/app/models/manageiq/providers/azure_stack/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure_stack/cloud_manager.rb
@@ -21,6 +21,10 @@ class ManageIQ::Providers::AzureStack::CloudManager < ManageIQ::Providers::Cloud
     build_network_manager(:type => 'ManageIQ::Providers::AzureStack::NetworkManager') unless network_manager
   end
 
+  def inventory_object_refresh?
+    true
+  end
+
   def ensure_managers_zone_and_provider_region
     network_manager.zone_id = zone_id if network_manager
     # provider_region is passed over via delegation so no need to copy-paste

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -41,7 +41,6 @@
 
 :ems_refresh:
   :azure_stack:
-    :inventory_object_refresh: true
     :allow_targeted_refresh: true
   :azure_stack_network:
     :inventory_object_refresh: true


### PR DESCRIPTION
Remove inventory_object_refresh from settings as part of the effort to remove the old legacy EmsRefresh and save_inventory refresh code.