### PR TITLE
Fix event_target_parser spec

### DIFF
--- a/app/models/manageiq/providers/azure_stack/cloud_manager/event_parser.rb
+++ b/app/models/manageiq/providers/azure_stack/cloud_manager/event_parser.rb
@@ -7,7 +7,7 @@ module ManageIQ::Providers::AzureStack::CloudManager::EventParser
     {
       :event_type => event_type(event),
       :source     => 'AZURESTACK',
-      :ems_ref    => full_data[:id].downcase,
+      :ems_ref    => full_data[:id]&.downcase,
       :timestamp  => full_data[:event_timestamp],
       :vm_ems_ref => full_data[:resource_type]&.downcase == INSTANCE_TYPE ? full_data[:resource_id]&.downcase : nil,
       :full_data  => full_data,

--- a/spec/models/manageiq/providers/azure_stack/cloud_manager/event_target_parser_spec.rb
+++ b/spec/models/manageiq/providers/azure_stack/cloud_manager/event_target_parser_spec.rb
@@ -20,11 +20,11 @@ describe ManageIQ::Providers::AzureStack::CloudManager::EventTargetParser do
   end
 
   def event_double(id)
-    double(
-      'event',
-      :resource_id     => id,
-      :event_timestamp => Time.now.utc
-    ).as_null_object
+    require 'azure_mgmt_monitor'
+    Azure::Monitor::Profiles::Latest::Mgmt::Models::EventData.new.tap do |event|
+      event.resource_id = id
+      event.event_timestamp = Time.now.utc
+    end
   end
 
   def assert_event_triggers_targets(event_data, expected_targets)


### PR DESCRIPTION
Rails 5.2 won't quote rspec mock doubles, this repo was missed in the cross_repo tests for the 5.2 upgrade.

Instead of trying to mock the event we can use the real EventData class so the test is more realistic.