### PR TITLE
Targeted refresh spec wasn't properly delivering the queue message

### DIFF
--- a/spec/models/manageiq/providers/azure_stack/cloud_manager/vcr_specs/targeted_refresh_spec.rb
+++ b/spec/models/manageiq/providers/azure_stack/cloud_manager/vcr_specs/targeted_refresh_spec.rb
@@ -145,8 +145,9 @@ describe ManageIQ::Providers::AzureStack::CloudManager::Refresher do
       refresh_job = MiqQueue.where(:method_name => 'refresh').first
 
       vcr_with_auth("#{described_class.name.underscore}_targeted/#{api_version}-#{cassette}") do
-        status, msg, _ = refresh_job.deliver
-        expect(:status => status, :msg => msg).not_to include(:status => 'error')
+        status, message, result = refresh_job.deliver
+        refresh_job.delivered(status, message, result)
+        expect(:status => status, :msg => message).not_to include(:status => 'error')
       end
 
       ems.reload


### PR DESCRIPTION
The targeted refresh spec test was confirming that there was only a
single queue message but it wasn't properly delivering the first one.