### PR TITLE
Internationalization cleanup

### DIFF
--- a/config/initializers/gettext.rb
+++ b/config/initializers/gettext.rb
@@ -1,5 +1,0 @@
-Vmdb::Gettext::Domains.add_domain(
-  'ManageIQ_Providers_AzureStack',
-  ManageIQ::Providers::AzureStack::Engine.root.join('locale').to_s,
-  :po
-)

--- a/zanata.xml
+++ b/zanata.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<config xmlns="http://zanata.org/namespace/config/">
-  <url>https://translate.zanata.org/</url>
-  <project>manageiq-providers-azure_stack</project>
-  <project-version>master</project-version>
-  <project-type>gettext</project-type>
-</config>


### PR DESCRIPTION
* drop `zanata.xml`, since it's not needed. All catalogs are part of core now.
* drop gettext initializer, it's not needed for the same reason

@miq-bot add_label cleanup