### PR TITLE
Update targeted refresh specs to use allow_any_instance_of

### DIFF
--- a/spec/models/manageiq/providers/azure_stack/cloud_manager/vcr_specs/targeted_refresh_spec.rb
+++ b/spec/models/manageiq/providers/azure_stack/cloud_manager/vcr_specs/targeted_refresh_spec.rb
@@ -13,7 +13,7 @@ describe ManageIQ::Providers::AzureStack::CloudManager::Refresher do
   supported_api_versions do |api_version|
     let!(:ems) do
       ems = FactoryBot.create(:ems_azure_stack_with_vcr_authentication, :skip_validate, :api_version => api_version)
-      allow(ems).to receive(:hostname_format_valid?).and_return(true) # or else "AZURE_STACK_HOST" gets rejected
+      allow_any_instance_of(ManageIQ::Providers::AzureStack::CloudManager).to receive(:hostname_format_valid?).and_return(true) # or else "AZURE_STACK_HOST" gets rejected
       ems
     end
 


### PR DESCRIPTION
It turns out that https://github.com/ManageIQ/manageiq/pull/20826 exposed a bug in the specs for azure-stack. This PR simply modifies them so that any instance AzureStack CloudManager instance will return true for `hostname_format_valid?`.