### PR TITLE
Replace deprecate method parent with module_parent

### DIFF
--- a/app/models/manageiq/providers/azure_stack/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/azure_stack/cloud_manager/event_catcher/runner.rb
@@ -24,7 +24,7 @@ class ManageIQ::Providers::AzureStack::CloudManager::EventCatcher::Runner < Mana
 
   def event_monitor_handle
     @event_monitor_handle ||= begin
-      self.class.parent::Stream.new(@ems)
+      self.class.module_parent::Stream.new(@ems)
     end
   end
 end


### PR DESCRIPTION
```
  1) ManageIQ::Providers::AzureStack::CloudManager::EventCatcher::Runner .monitor_events
     Failure/Error: self.class.parent::Stream.new(@ems)

     NoMethodError:
       undefined method `parent' for #<Class:0x000056426dcc23a0>
       Did you mean?  present?
```