### PR TITLE
Use add_cloud_collection to fix Network parent

### DIFF
--- a/app/models/manageiq/providers/azure_stack/inventory/persister/definitions/cloud_collections.rb
+++ b/app/models/manageiq/providers/azure_stack/inventory/persister/definitions/cloud_collections.rb
@@ -12,7 +12,7 @@ module ManageIQ::Providers::AzureStack::Inventory::Persister::Definitions::Cloud
       orchestration_stacks
       resource_groups
     ].each do |name|
-      add_collection(cloud, name)
+      add_cloud_collection(name)
     end
   end
 end

--- a/app/models/manageiq/providers/azure_stack/inventory/persister/definitions/network_collections.rb
+++ b/app/models/manageiq/providers/azure_stack/inventory/persister/definitions/network_collections.rb
@@ -11,16 +11,15 @@ module ManageIQ::Providers::AzureStack::Inventory::Persister::Definitions::Netwo
        cloud_subnets
        network_ports
        security_groups].each do |name|
-      add_collection(network, name)
+      add_network_collection(name)
     end
   end
 
   def add_related_cloud_collections
     %i[resource_groups
        vms].each do |name|
-      add_collection(cloud, name) do |builder|
+      add_cloud_collection(name) do |builder|
         builder.add_properties(
-          :parent   => manager.parent_manager,
           :strategy => :local_db_find_references
         )
       end


### PR DESCRIPTION
Use the add_cloud_collection() method to set the correct parent when referencing cloud_manager inventory from the network_manager

Fixes https://github.com/ManageIQ/manageiq-cross_repo-tests/runs/6598733836?check_suite_focus=true#step:6:2329

Required for:
* https://github.com/ManageIQ/manageiq/pull/21650