### PR TITLE
ruby 3 support

### DIFF
--- a/app/models/manageiq/providers/azure_stack/cloud_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/azure_stack/cloud_manager/event_catcher/runner.rb
@@ -24,7 +24,7 @@ class ManageIQ::Providers::AzureStack::CloudManager::EventCatcher::Runner < Mana
 
   def event_monitor_handle
     @event_monitor_handle ||= begin
-      self.class.parent::Stream.new(@ems)
+      self.class.module_parent::Stream.new(@ems)
     end
   end
 end

--- a/app/models/manageiq/providers/azure_stack/cloud_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/azure_stack/cloud_manager/event_catcher/stream.rb
@@ -27,7 +27,7 @@ class ManageIQ::Providers::AzureStack::CloudManager::EventCatcher::Stream
             @since ||= initial_time
 
             filter = "eventTimestamp ge #{@since.iso8601(3)}"
-            events = connection.activity_logs.list(:filter => filter).sort_by(&:event_timestamp)
+            events = connection.activity_logs.list({:filter => filter}).sort_by(&:event_timestamp)
             yield events
 
             @since = update_time(events) unless events.empty?

--- a/spec/models/manageiq/providers/azure_stack/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/azure_stack/cloud_manager/orchestration_stack_spec.rb
@@ -9,7 +9,7 @@ describe ManageIQ::Providers::AzureStack::CloudManager::OrchestrationStack do
 
     before do
       allow_any_instance_of(MsRestAzure::Common::Configurable).to receive(:reset!)
-      allow(ems).to receive(:connect).with(:service => :Resources).and_return(client)
+      allow(ems).to receive(:connect).with({:service => :Resources}).and_return(client)
     end
 
     subject do

--- a/spec/models/manageiq/providers/azure_stack/cloud_manager/vcr_specs/event_stream_spec.rb
+++ b/spec/models/manageiq/providers/azure_stack/cloud_manager/vcr_specs/event_stream_spec.rb
@@ -4,7 +4,7 @@ describe ManageIQ::Providers::AzureStack::CloudManager::EventCatcher::Stream do
   let(:capture_since) { Time.parse('2019-01-07T20:00:00Z').utc }
   let!(:ems)          { FactoryBot.create(:ems_azure_stack_with_vcr_authentication, :skip_validate, :api_version => api_version) }
 
-  subject { described_class.new(ems, :since => capture_since) }
+  subject { described_class.new(ems, {:since => capture_since}) }
 
   supported_api_versions do |api_version|
     describe '#poll' do


### PR DESCRIPTION
- Fix parent -> module_parent (rails 6.1)
- Explicit hash vs. kwargs (ruby 3)