### PR TITLE
Make backward compatible zeitwerk friendly changes

### DIFF
--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,0 +1,8 @@
+# TODO: Revisit if we should rename these classes and change how we "locate" these constants
+# See: https://github.com/ManageIQ/manageiq-providers-azure_stack/blob/6cd355f74ccaca8c503c5026d2974b808cf241eb/app/models/manageiq/providers/azure_stack/inventory.rb#L16
+Rails.autoloaders.each do |autoloader|
+  autoloader.inflector.inflect(
+    'v2017_03_09' => "V2017_03_09",
+    'v2018_03_01' => "V2018_03_01"
+  )
+end

--- a/lib/manageiq-providers-azure_stack.rb
+++ b/lib/manageiq-providers-azure_stack.rb
@@ -1,2 +1,0 @@
-require "manageiq/providers/azure_stack/engine"
-require "manageiq/providers/azure_stack/version"

--- a/lib/manageiq/providers/azure_stack.rb
+++ b/lib/manageiq/providers/azure_stack.rb
@@ -1,1 +1,2 @@
 require "manageiq/providers/azure_stack/engine"
+require "manageiq/providers/azure_stack/version"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ end
 Dir[Rails.root.join("spec/shared/**/*.rb")].each { |f| require f }
 Dir[File.join(__dir__, "support/**/*.rb")].each { |f| require f }
 
-require "manageiq-providers-azure_stack"
+require "manageiq/providers/azure_stack"
 
 VCR.configure do |config|
   config.ignore_hosts 'codeclimate.com' if ENV['CI']


### PR DESCRIPTION
* Drop lib/gem-name.rb in favor of lib/gem/name.rb
* Teach the rails autoloader how to load unconventionally named classes