### PR TITLE
Drop require_nested

### DIFF
--- a/app/models/manageiq/providers/azure_stack/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure_stack/cloud_manager.rb
@@ -1,17 +1,4 @@
 class ManageIQ::Providers::AzureStack::CloudManager < ManageIQ::Providers::CloudManager
-  require_nested :AvailabilityZone
-  require_nested :EventCatcher
-  require_nested :EventParser
-  require_nested :Flavor
-  require_nested :MetricsCapture
-  require_nested :Refresher
-  require_nested :RefreshWorker
-  require_nested :ResourceGroup
-  require_nested :Vm
-  require_nested :OrchestrationStack
-  require_nested :OrchestrationTemplate
-  require_nested :OrchestrationServiceOptionConverter
-
   include ManageIQ::Providers::AzureStack::ManagerMixin
 
   alias_attribute :azure_tenant_id, :uid_ems

--- a/app/models/manageiq/providers/azure_stack/cloud_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/azure_stack/cloud_manager/event_catcher.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::AzureStack::CloudManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
-  require_nested :Runner
 end

--- a/app/models/manageiq/providers/azure_stack/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/azure_stack/cloud_manager/orchestration_stack.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::AzureStack::CloudManager::OrchestrationStack < ManageIQ::Providers::CloudManager::OrchestrationStack
-  require_nested :Status
-
   def self.raw_create_stack(ems, stack_name, template, options = {})
     create_or_update_stack(ems, stack_name, template, options)
   rescue => err

--- a/app/models/manageiq/providers/azure_stack/cloud_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/azure_stack/cloud_manager/refresh_worker.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::AzureStack::CloudManager::RefreshWorker < MiqEmsRefreshWorker
-  require_nested :Runner
 end

--- a/app/models/manageiq/providers/azure_stack/inventory.rb
+++ b/app/models/manageiq/providers/azure_stack/inventory.rb
@@ -1,8 +1,4 @@
 class ManageIQ::Providers::AzureStack::Inventory < ManageIQ::Providers::Inventory
-  require_nested :Collector
-  require_nested :Parser
-  require_nested :Persister
-
   # Default manager for building collector/parser/persister classes
   # when failed to get class name from refresh target automatically
   def self.default_manager_name

--- a/app/models/manageiq/providers/azure_stack/inventory/collector.rb
+++ b/app/models/manageiq/providers/azure_stack/inventory/collector.rb
@@ -1,7 +1,4 @@
 class ManageIQ::Providers::AzureStack::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
-  require_nested :CloudManager
-  require_nested :TargetCollection
-
   include ManageIQ::Providers::AzureStack::EmsRefMixin
 
   def initialize(manager, refresh_target)

--- a/app/models/manageiq/providers/azure_stack/inventory/collector/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure_stack/inventory/collector/cloud_manager.rb
@@ -1,9 +1,6 @@
 # This class contains a reference implementation of collector for CloudManager.
 # The methods implemented here are completely aligned with the V2018_03_01 version profile.
 class ManageIQ::Providers::AzureStack::Inventory::Collector::CloudManager < ManageIQ::Providers::AzureStack::Inventory::Collector
-  require_nested :V2018_03_01
-  require_nested :V2017_03_09
-
   def resource_groups
     @resource_groups ||= azure_resources.resource_groups.list
   end

--- a/app/models/manageiq/providers/azure_stack/inventory/collector/network_manager.rb
+++ b/app/models/manageiq/providers/azure_stack/inventory/collector/network_manager.rb
@@ -1,9 +1,6 @@
 # This class contains a reference implementation of collector for NetworkManager.
 # The methods implemented here are completely aligned with the V2018_03_01 version profile.
 class ManageIQ::Providers::AzureStack::Inventory::Collector::NetworkManager < ManageIQ::Providers::AzureStack::Inventory::Collector
-  require_nested :V2018_03_01
-  require_nested :V2017_03_09
-
   def networks
     azure_network.virtual_networks.list_all
   end

--- a/app/models/manageiq/providers/azure_stack/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/azure_stack/inventory/collector/target_collection.rb
@@ -1,7 +1,4 @@
 class ManageIQ::Providers::AzureStack::Inventory::Collector::TargetCollection < ManageIQ::Providers::AzureStack::Inventory::Collector
-  require_nested :V2018_03_01
-  require_nested :V2017_03_09
-
   def initialize(manager, target)
     super
 

--- a/app/models/manageiq/providers/azure_stack/inventory/parser.rb
+++ b/app/models/manageiq/providers/azure_stack/inventory/parser.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::AzureStack::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
-  require_nested :CloudManager
 end

--- a/app/models/manageiq/providers/azure_stack/inventory/persister.rb
+++ b/app/models/manageiq/providers/azure_stack/inventory/persister.rb
@@ -1,5 +1,2 @@
 class ManageIQ::Providers::AzureStack::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
-  require_nested :CloudManager
-  require_nested :NetworkManager
-  require_nested :TargetCollection
 end

--- a/app/models/manageiq/providers/azure_stack/network_manager.rb
+++ b/app/models/manageiq/providers/azure_stack/network_manager.rb
@@ -1,11 +1,4 @@
 class ManageIQ::Providers::AzureStack::NetworkManager < ManageIQ::Providers::NetworkManager
-  require_nested :RefreshWorker
-  require_nested :Refresher
-  require_nested :CloudNetwork
-  require_nested :CloudSubnet
-  require_nested :NetworkPort
-  require_nested :SecurityGroup
-
   delegate :api_version,
            :authentication_check,
            :authentication_status,

--- a/app/models/manageiq/providers/azure_stack/network_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/azure_stack/network_manager/refresh_worker.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::AzureStack::NetworkManager::RefreshWorker < ::MiqEmsRefreshWorker
-  require_nested :Runner
-
   def self.settings_name
     :ems_refresh_worker_azure_stack_network
   end


### PR DESCRIPTION
Zeitwerk completely removes the need for these methods. See also: https://github.com/ManageIQ/manageiq/pull/22854