### PR TITLE
Use forked gems with smaller footprint

### DIFF
--- a/manageiq-providers-azure_stack.gemspec
+++ b/manageiq-providers-azure_stack.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'azure_mgmt_compute', '~> 0.20'
-  spec.add_runtime_dependency 'azure_mgmt_monitor', '~> 0.17'
-  spec.add_runtime_dependency 'azure_mgmt_network', '~> 0.24'
-  spec.add_runtime_dependency 'azure_mgmt_resources', '~> 0.18'
+  spec.add_runtime_dependency 'azure_mgmt_compute', '~> 0.22.0.1'
+  spec.add_runtime_dependency 'azure_mgmt_monitor', '~> 0.19.0.1'
+  spec.add_runtime_dependency 'azure_mgmt_network', '~> 0.26.1.1'
+  spec.add_runtime_dependency 'azure_mgmt_resources', '~> 0.18.2.1'
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"


### PR DESCRIPTION
This PR uses a fork of the azure-sdk-for-ruby with unused APIs and profiles removed.

This builds on the https://github.com/ManageIQ/azure-sdk-for-ruby/tree/azure-sdk-for-ruby_production branch which [adds a commit with a script](https://github.com/ManageIQ/azure-sdk-for-ruby/commit/7e97955fdf78754f0502ae7855791c0706b0d96f) for dropping gem sizes, then executes that script and commits it as the next 8 commits. I've tested this locally with the azure stack PR and all of the tests pass, and additionally I have tried to autoload every autoloadable constant and that also works.

Time to load:

```
azure_mgmt_network
  4.195398   1.299338   5.494736 (  5.541836)   # Before - Initial autoload everything
  0.662541   0.218067   0.880608 (  0.889964)   # After - Autoload after purge unused APIs
  0.313432   0.132122   0.445554 (  0.462570)   # After - Autoload after purge profiles
```

Disk usage:

```
Before:
 26M	azure_mgmt_compute-0.22.0
3.5M	azure_mgmt_monitor-0.19.0
140M	azure_mgmt_network-0.26.1
8.4M	azure_mgmt_resources-0.18.2
177.9M	total

After:
2.5M	azure_mgmt_compute-0.22.0.1
2.0M	azure_mgmt_monitor-0.19.0.1
4.5M	azure_mgmt_network-0.26.1.1
1.0M	azure_mgmt_resources-0.18.2.1
10.0M	total (167.9MB / 94% smaller)
```

---

The high level way the script works is that it comments out all of the "require" lines for the gem in question, then tries to eager load every profile and every autoloadable constant under that profile recursively.  When it blows up, it captures which constant was missing, uncomments that line, and tries again.  It keeps doing this until the gem no longer blows up. Then, everything that's still commented out is clearly not needed, so it deletes all those require lines as well as the api directories.  This script is written generically, so if we need to add a new gem in the future, or we need to include a newer profile, it should be trivial to re-purge it with this script, restoring what was deleted or deleting what is newly no longer needed.

Closes ManageIQ/manageiq-pods#737