### PR TITLE
Delegate refresh_ems class method to parent cloud manager

### DIFF
--- a/app/models/manageiq/providers/azure_stack/network_manager.rb
+++ b/app/models/manageiq/providers/azure_stack/network_manager.rb
@@ -19,6 +19,10 @@ class ManageIQ::Providers::AzureStack::NetworkManager < ManageIQ::Providers::Net
            :to        => :parent_manager,
            :allow_nil => true
 
+  class << self
+    delegate :refresh_ems, :to => ManageIQ::Providers::AzureStack::CloudManager
+  end
+
   def description
     provider_region
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -44,6 +44,7 @@
     :allow_targeted_refresh: true
   :azure_stack_network:
     :allow_targeted_refresh: true
+    :refresh_interval: 0
 
 :log:
   :level_azure_stack: info


### PR DESCRIPTION
Reasoning here: https://github.com/ManageIQ/manageiq-providers-azure/pull/564#issuecomment-2445034651

@miq-bot assign @agrare
@miq-bot add_label bug, radjabov/yes?
@miq-bot add_reviewer @agrare